### PR TITLE
Be more resiliant (to things like NullHandler) when looking through log handlers.

### DIFF
--- a/aminator/config.py
+++ b/aminator/config.py
@@ -170,7 +170,7 @@ def configure_datetime_logfile(config, handler):
 
     # find handler amongst all the loggers and reassign the filename/stream
     for h in [x for l in logging.root.manager.loggerDict for x in logging.getLogger(l).handlers] + logging.root.handlers:
-        if h.name == handler:
+        if getattr(h, 'name', '') == handler:
             assert isinstance(h, logging.FileHandler)
             h.stream.close()
             h.baseFilename = filename


### PR DESCRIPTION
On a clean `aminator` install, I was getting the following error:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "aminator/cli.py", line 51, in run
    sys.exit(Aminator(debug=args.debug).aminate())
  File "aminator/core.py", line 52, in __init__
    configure_datetime_logfile(self.config, 'aminator')
  File "aminator/config.py", line 174, in configure_datetime_logfile
    if h.name == handler:
AttributeError: NullHandler instance has no attribute 'name'
```

I presume this is due to some missing configuration, but in any case the code should be able to deal with this without blowing up. :-)
