### PR TITLE
Always attach volumes to a major device.

### DIFF
--- a/aminator/plugins/blockdevice/linux.py
+++ b/aminator/plugins/blockdevice/linux.py
@@ -57,11 +57,10 @@ class LinuxBlockDevicePlugin(BaseBlockDevicePlugin):
 
         majors = block_config.device_letters
         self._device_prefix = native_device_prefix(block_config.device_prefixes)
-        device_format = '/dev/{0}{1}{2}'
+        device_format = '/dev/{0}{1}'
 
-        self._allowed_devices = [device_format.format(self._device_prefix, major, minor)
-                                 for major in majors
-                                 for minor in xrange(1, 16)]
+        self._allowed_devices = [device_format.format(self._device_prefix, major)
+                                 for major in majors]
 
     def __enter__(self):
         with flock(self._lock_file):

--- a/aminator/plugins/volume/linux.py
+++ b/aminator/plugins/volume/linux.py
@@ -27,7 +27,7 @@ import logging
 import os
 
 from aminator.util import retry
-from aminator.util.linux import MountSpec, busy_mount, mount, mounted, unmount
+from aminator.util.linux import MountSpec, busy_mount, filesystem, mount, mounted, unmount
 from aminator.exceptions import VolumeException
 from aminator.plugins.volume.base import BaseVolumePlugin
 
@@ -56,7 +56,12 @@ class LinuxVolumePlugin(BaseVolumePlugin):
             os.makedirs(self._mountpoint)
 
         if not mounted(self._mountpoint):
-            mountspec = MountSpec(self._dev, None, self._mountpoint, None)
+            if filesystem(self._dev).success:
+                dev = self._dev
+            else:
+                # assume the first partition
+                dev = self._dev + "1"
+            mountspec = MountSpec(dev, None, self._mountpoint, None)
             result = mount(mountspec)
             if not result.success:
                 msg = 'Unable to mount {0.dev} at {0.mountpoint}: {1}'.format(mountspec, result.result.std_err)

--- a/aminator/util/linux.py
+++ b/aminator/util/linux.py
@@ -74,6 +74,10 @@ def mounted(path):
     with open('/proc/mounts') as mounts:
         return any(pat in mount for mount in mounts)
 
+@command()
+def filesystem(dev):
+    return 'blkid -u filesystem {0}'.format(dev)
+
 
 @command()
 def fsck(dev):


### PR DESCRIPTION
Attaching volumes to minor devices (e.g. /dev/sdf1) causes problems if
the volume has a partition table. We can always attach to the major
device (/dev/sdf) then use blkid to check for a filesystem. If it doesn't
find one on the major device, assume the filesystem we want is on the
first partition/minor device (e.g. /dev/sdf1).

This fixes https://github.com/Netflix/aminator/issues/59.
