### PR TITLE
allow provision_config_files to be directories

### DIFF
--- a/aminator/util/linux.py
+++ b/aminator/util/linux.py
@@ -390,7 +390,6 @@ def remove_provision_config(src, dstpath, backup_ext='_aminator'):
                     shutil.rmtree(dst)
                 else:
                     os.remove(dst)
-                remove(dst)
                 log.debug('Provision config {0} removed'.format(dst))
             except Exception:
                 log.exception('Error encountered while removing {0}'.format(dst))


### PR DESCRIPTION
sometimes it will be useful to copy entire trees into the chroot during provisioniong, for instance to copy yum cache files so you don't need to refetch them during provisioning.
