### PR TITLE
add --preserve-on-error global option

### DIFF
--- a/aminator/config.py
+++ b/aminator/config.py
@@ -229,6 +229,8 @@ def add_base_arguments(parser, config):
                           ' a file system path or http url to the package file.')
     parser.add_config_arg('-e', '--environment', config=config.context,
                           help='The environment configuration for amination')
+    parser.add_config_arg('--preserve-on-error', action='store_true', config=config.context,
+                          help='For Debugging. Preserve build chroot on error')
     parser.add_argument('--version', action='version', version='%(prog)s {0}'.format(aminator.__version__))
     parser.add_argument('--debug', action='store_true', help='Verbose debugging output')
 

--- a/aminator/plugins/provisioner/linux.py
+++ b/aminator/plugins/provisioner/linux.py
@@ -259,6 +259,8 @@ class BaseLinuxProvisionerPlugin(BaseProvisionerPlugin):
         return self
 
     def __exit__(self, exc_type, exc_value, trace):
+        if exc_type and self._config.context.preserve_on_error:
+            return False
         if not self._teardown_chroot():
             raise VolumeException('Error tearing down chroot')
         return False

--- a/aminator/plugins/volume/linux.py
+++ b/aminator/plugins/volume/linux.py
@@ -83,6 +83,8 @@ class LinuxVolumePlugin(BaseVolumePlugin):
         return self._mountpoint
 
     def __exit__(self, exc_type, exc_value, trace):
+        if exc_type and self._config.context.preserve_on_error:
+            return False
         self._unmount()
         self._detach()
         self._delete()


### PR DESCRIPTION
To ease debugging when something goes wrong during the setup/install process I have added a --preserve-on-error option which will skip the chroot teardown and volume umount/detach/destroy when an exception is detected.
