### PR TITLE
Block device mappings should not be required.

### DIFF
--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -327,8 +327,9 @@ class EC2CloudPlugin(BaseCloudPlugin):
         bdm = BlockDeviceMapping(connection=self._connection)
         bdm[root_block_device] = BlockDeviceType(snapshot_id=self._snapshot.id,
                                                  delete_on_termination=True)
-        for (os_dev, ec2_dev) in block_device_map:
-            bdm[os_dev] = BlockDeviceType(ephemeral_name=ec2_dev)
+        if not block_device_map is None:
+            for (os_dev, ec2_dev) in block_device_map:
+                bdm[os_dev] = BlockDeviceType(ephemeral_name=ec2_dev)
         return bdm
 
     @retry(FinalizerException, tries=3, delay=1, backoff=2, logger=log)


### PR DESCRIPTION
If the tagging_ebs finalizer plugin's config is overwritten to remove
the "ephemeral" mappings (thereby setting default_block_device_map to
None), _make_block_device_map would blow up. This patch checks for
None before trying to iterate.
