### PR TITLE
allow for https sources in chef provisioner

### DIFF
--- a/aminator/config.py
+++ b/aminator/config.py
@@ -231,6 +231,8 @@ def add_base_arguments(parser, config):
                           help='The environment configuration for amination')
     parser.add_config_arg('--preserve-on-error', action='store_true', config=config.context,
                           help='For Debugging. Preserve build chroot on error')
+    parser.add_config_arg('--verify-https', action='store_true', config=config.context,
+                          help='Specify if one wishes for plugins to verify SSL certs when hitting https URLs')
     parser.add_argument('--version', action='version', version='%(prog)s {0}'.format(aminator.__version__))
     parser.add_argument('--debug', action='store_true', help='Verbose debugging output')
 

--- a/aminator/default_conf/aminator.yml
+++ b/aminator/default_conf/aminator.yml
@@ -37,6 +37,8 @@ plugins:
         class: VolumePluginManager
 
 context:
+  # used by some plugins when fetching resources
+  verify_https: false
   package:
     # AMI directory to store package files
     dir: /tmp

--- a/aminator/plugins/provisioner/apt_chef.py
+++ b/aminator/plugins/provisioner/apt_chef.py
@@ -130,7 +130,8 @@ class AptChefProvisionerPlugin(AptProvisionerPlugin):
                 local_chef_package_file = context.chef.dir + '/' + chef_package_name
                 log.debug('preparing to download {0} to {1}'.format(context.chef.chef_package_url,
                                                                     local_chef_package_file))
-                download_file(context.chef.chef_package_url, local_chef_package_file, context.package.get('timeout', 1))
+                download_file(context.chef.chef_package_url, local_chef_package_file,
+                              context.package.get('timeout', 1), verify_https=context.get('verify_https', False))
                 log.debug('preparing to do a dpkg -i {0}'.format(chef_package_name))
                 dpkg_install(local_chef_package_file)
 

--- a/aminator/plugins/provisioner/linux.py
+++ b/aminator/plugins/provisioner/linux.py
@@ -302,7 +302,8 @@ class BaseLinuxProvisionerPlugin(BaseProvisionerPlugin):
         pkg_url = context.package.arg
         dst_file_path = context.package.full_path
         log.debug('downloading {0} to {1}'.format(pkg_url, dst_file_path))
-        download_file(pkg_url, dst_file_path, context.package.get('timeout', 1))
+        download_file(pkg_url, dst_file_path, context.package.get('timeout', 1),
+                      verify_https=context.get('verify_https', False))
 
     def _move_pkg(self, context):
         src_file = context.package.arg.replace('file://', '')

--- a/aminator/util/__init__.py
+++ b/aminator/util/__init__.py
@@ -78,9 +78,9 @@ def memoize(obj=None):
 
 
 @retry(requests.HTTPError, tries=5, delay=1, backoff=2)
-def download_file(url, dst, timeout=1):
+def download_file(url, dst, timeout=1, verify_https=False):
     try:
-        response = requests.get(url, timeout=timeout)
+        response = requests.get(url, timeout=timeout, verify=verify_https)
     except requests.RequestException as e:
         if isinstance(e, requests.Timeout):
             # Retry timeouts


### PR DESCRIPTION
apt_chef should allow for https URIs. This _could_ probably be extracted out into a utility method if need be, but this should fix the problem for starters.
