### PR TITLE
Do not abort failed local install when dpkg -i fails

### DIFF
--- a/aminator/plugins/provisioner/apt.py
+++ b/aminator/plugins/provisioner/apt.py
@@ -89,7 +89,7 @@ def apt_get_localinstall(package):
     dpkg_ret = dpkg_install(package)
     if not dpkg_ret.success:
         log.debug('failure:{0.command} :{0.stderr}'.format(dpkg_ret.result))
-        apt_ret = apt_get_install('--fix-missing')
+        apt_ret = apt_get_install('-f')
         if not apt_ret.success:
             log.debug('failure:{0.command} :{0.stderr}'.format(apt_ret.result))
             return apt_ret


### PR DESCRIPTION
If the .deb has missing dependencies then dpkg -i will fail and we will never get to the apt-get install -f which fixes the missing dependencies.
