### PR TITLE
fix typos and log exceptions in __exit__

### DIFF
--- a/aminator/environment.py
+++ b/aminator/environment.py
@@ -65,6 +65,7 @@ class Environment(object):
         return self
 
     def __exit__(self, exc_type, exc_value, trc):
+        if exc_type: log.exception("Exception: {0}: {1}".format(exc_type.__name__,exc_value))
         return False
 
     def __call__(self, config, plugin_manager):

--- a/aminator/plugins/blockdevice/base.py
+++ b/aminator/plugins/blockdevice/base.py
@@ -46,6 +46,7 @@ class BaseBlockDevicePlugin(BasePlugin):
 
     @abc.abstractmethod
     def __exit__(self, typ, val, trc):
+        if typ: log.exception("Exception: {0}: {1}".format(typ.__name__,val))
         return False
 
     def __call__(self, cloud):

--- a/aminator/plugins/blockdevice/linux.py
+++ b/aminator/plugins/blockdevice/linux.py
@@ -70,8 +70,10 @@ class LinuxBlockDevicePlugin(BaseBlockDevicePlugin):
         return self._dev.node
 
     def __exit__(self, typ, val, trc):
+        if typ: log.exception("Exception: {0}: {1}".format(typ.__name__,val))
         fcntl.flock(self._dev.handle, fcntl.LOCK_UN)
         self._dev.handle.close()
+        return False
 
     def find_available_dev(self):
         log.info('Searching for an available block device')

--- a/aminator/plugins/cloud/base.py
+++ b/aminator/plugins/cloud/base.py
@@ -95,4 +95,5 @@ class BaseCloudPlugin(BasePlugin):
         return self
 
     def __exit__(self, typ, val, trc):
+        if typ: log.exception("Exception: {0}: {1}".format(typ.__name__,val))
         return False

--- a/aminator/plugins/distro/base.py
+++ b/aminator/plugins/distro/base.py
@@ -48,6 +48,7 @@ class BaseDistroPlugin(BasePlugin):
 
     @abc.abstractmethod
     def __exit__(self, exc_type, exc_value, trace):
+        if exc_type: log.exception("Exception: {0}: {1}".format(exc_type.__name__,exc_value))
         return False
 
     def __call__(self, mountpoint):

--- a/aminator/plugins/distro/linux.py
+++ b/aminator/plugins/distro/linux.py
@@ -136,14 +136,14 @@ class BaseLinuxDistroPlugin(BaseDistroPlugin):
                 continue
             result = unmount(mountspec.mountpoint)
             if not result.success:
-                log.error('Unable to unmount {0.mountpoint}: {1.stderr}'.format(mountspec, result))
+                log.error('Unable to unmount {0.mountpoint}: {1.std_err}'.format(mountspec, result))
                 return False
         log.debug('Checking for stray mounts')
         for mountpoint in lifo_mounts(self._mountpoint):
             log.debug('Stray mount found: {0}, attempting to unmount'.format(mountpoint))
             result = unmount(mountpoint)
             if not result.success:
-                log.error('Unable to unmount {0.mountpoint}: {1.stderr}'.format(mountspec, result))
+                log.error('Unable to unmount {0.mountpoint}: {1.std_err}'.format(mountspec, result))
                 return False
         log.debug('Teardown of chroot mounts succeeded!')
         return True
@@ -168,6 +168,7 @@ class BaseLinuxDistroPlugin(BaseDistroPlugin):
         return self
 
     def __exit__(self, exc_type, exc_value, trace):
+        if exc_type: log.exception("Exception: {0}: {1}".format(exc_type.__name__,exc_value))
         if exc_type and self._config.context.get("preserve_on_error", False):
             return False
         if not self._teardown_chroot():

--- a/aminator/plugins/finalizer/base.py
+++ b/aminator/plugins/finalizer/base.py
@@ -50,6 +50,7 @@ class BaseFinalizerPlugin(BasePlugin):
         return self
 
     def __exit__(self, typ, val, trc):
+        if typ: log.exception("Exception: {0}: {1}".format(typ.__name__,val))
         return False
 
     def __call__(self, cloud):

--- a/aminator/plugins/finalizer/tagging_ebs.py
+++ b/aminator/plugins/finalizer/tagging_ebs.py
@@ -153,6 +153,7 @@ class TaggingEBSFinalizerPlugin(BaseFinalizerPlugin):
         return self
 
     def __exit__(self, exc_type, exc_value, trace):
+        if exc_type: log.exception("Exception: {0}: {1}".format(exc_type.__name__,exc_value))
         return False
 
     def __call__(self, cloud):

--- a/aminator/plugins/provisioner/apt.py
+++ b/aminator/plugins/provisioner/apt.py
@@ -88,11 +88,11 @@ def apt_get_localinstall(package):
     """
     dpkg_ret = dpkg_install(package)
     if not dpkg_ret.success:
-        log.debug('failure:{0.command} :{0.stderr}'.format(dpkg_ret.result))
+        log.debug('failure:{0.command} :{0.std_err}'.format(dpkg_ret.result))
         apt_ret = apt_get_install('-f')
         if not apt_ret.success:
-            log.debug('failure:{0.command} :{0.stderr}'.format(apt_ret.result))
-            return apt_ret
+            log.debug('failure:{0.command} :{0.std_err}'.format(apt_ret.result))
+        return apt_ret
     return dpkg_ret
 
 

--- a/aminator/plugins/volume/base.py
+++ b/aminator/plugins/volume/base.py
@@ -49,6 +49,7 @@ class BaseVolumePlugin(BasePlugin):
 
     @abc.abstractmethod
     def __exit__(self, exc_type, exc_value, trace):
+        if exc_type: log.exception("Exception: {0}: {1}".format(exc_type.__name__,exc_value))
         return False
 
     def __call__(self, cloud, blockdevice):

--- a/aminator/plugins/volume/linux.py
+++ b/aminator/plugins/volume/linux.py
@@ -83,6 +83,7 @@ class LinuxVolumePlugin(BaseVolumePlugin):
         return self._mountpoint
 
     def __exit__(self, exc_type, exc_value, trace):
+        if exc_type: log.exception("Exception: {0}: {1}".format(exc_type.__name__,exc_value))
         if exc_type and self._config.context.get("preserve_on_error", False):
             return False
         self._unmount()

--- a/aminator/util/linux.py
+++ b/aminator/util/linux.py
@@ -133,7 +133,7 @@ def keyval_parse(record_sep='\n', field_sep=':'):
                     continue
                 metadata[key.strip()] = val.strip()
         else:
-            log.debug('failure:{0.command} :{0.stderr}'.format(ret.result))
+            log.debug('failure:{0.command} :{0.std_err}'.format(ret.result))
         return metadata
     return _parse
 
@@ -153,6 +153,7 @@ class Chroot(object):
         return self
 
     def __exit__(self, typ, exc, trc):
+        if typ: log.exception("Exception: {0}: {1}".format(typ.__name__,val))
         log.debug('Leaving chroot')
         os.fchdir(self.real_root)
         os.chroot('.')


### PR DESCRIPTION
- log when exception detected in **exit** for context managers (otherwise it will never be logged)
- fix typos from stderr vs std_err for command results
