### PR TITLE
convert default_ec2_user to string if read from config file

### DIFF
--- a/aminator/plugins/finalizer/tagging_s3.py
+++ b/aminator/plugins/finalizer/tagging_s3.py
@@ -103,7 +103,7 @@ class TaggingS3FinalizerPlugin(TaggingBaseFinalizerPlugin):
         cmd = ['ec2-bundle-image']
         cmd.extend(['-c', context.ami.get("cert", config.default_cert)])
         cmd.extend(['-k', context.ami.get("privatekey", config.default_privatekey)])
-        cmd.extend(['-u', context.ami.get("ec2_user", config.default_ec2_user)])
+        cmd.extend(['-u', context.ami.get("ec2_user", str(config.default_ec2_user))])
         cmd.extend(['-i', self.image_location()])
         cmd.extend(['-d', self.tmpdir()])
         if context.base_ami.architecture:


### PR DESCRIPTION
otherwise yaml will parse as an int and the command will throw a python exception
