### PR TITLE
sanitize PATH for subcommands when running inside a virtualenv

### DIFF
--- a/aminator/util/linux.py
+++ b/aminator/util/linux.py
@@ -86,14 +86,8 @@ def monitor_command(cmd, timeout=None):
     
     # sanitize PATH if we are running in a virtualenv
     env = copy(environ)
-    log.debug("PREFIX: {}".format(sys.prefix))
-    log.debug("HASATTR REAL_PREFIX: {}".format(hasattr(sys, "real_prefix")))
     if hasattr(sys, "real_prefix"):
-        log.debug("REAL PREFIX: {}".format(sys.real_prefix))
         env["PATH"] = string.replace(env["PATH"], "{}/bin:".format(sys.prefix), "")
-
-    for key in env:
-        log.debug("{}={}".format(key,env[key]))
 
     proc = Popen(cmd,stdout=PIPE,stderr=PIPE,close_fds=True,shell=shell,env=env)
     set_nonblocking(proc.stdout)
@@ -120,7 +114,7 @@ def monitor_command(cmd, timeout=None):
                 io.remove(fd)
             else:
                 if fd == proc.stderr:
-                    log.error(buf)
+                    log.debug("STDERR: {}".format(buf))
                     std_err += buf
                 else:
                     if buf[-1] == "\n":


### PR DESCRIPTION
Otherwise running python scripts in package post-install scripts get confused in a multitude of ways, for instance:
Traceback (most recent call last):
  File "/opt/python/bin/virtualenv", line 8, in <module>
    from pkg_resources import load_entry_point
ImportError: No module named pkg_resources
