### PR TITLE
increase volume unmount retires; VolumeException on unmount now frequent with Amazon Linux 2014.03

### DIFF
--- a/aminator/plugins/volume/linux.py
+++ b/aminator/plugins/volume/linux.py
@@ -64,7 +64,7 @@ class LinuxVolumePlugin(BaseVolumePlugin):
                 raise VolumeException(msg)
         log.debug('Mounted {0.dev} at {0.mountpoint} successfully'.format(mountspec))
 
-    @retry(VolumeException, tries=3, delay=1, backoff=2, logger=log)
+    @retry(VolumeException, tries=6, delay=1, backoff=2, logger=log)
     def _unmount(self):
         if mounted(self._mountpoint):
             if busy_mount(self._mountpoint).success:


### PR DESCRIPTION
We're seeing frequent VolumeException on unmount since upgrading to Amazon Linux 2014.03.  Exceptions were not seen with Amazon Linux 2013.09

Increasing the unmount retries has helped reduce the occurrence of the unmount exception.

Exception observed:

```
aminator.exceptions.VolumeException: Unable to unmount /dev/xvdf1 from /var/aminator/volumes/xvdf1: umount: /var/aminator/volumes/xvdf1: target is busy.
              (In some cases useful info about processes that use
               the device is found by lsof(8) or fuser(1))

              (In some cases useful info about processes that use
               the device is found by lsof(8) or fuser(1))

      Result: 1
```
