### PR TITLE
short circuit /usr/sbin/service on ubuntu

### DIFF
--- a/aminator/plugins/distro/base.py
+++ b/aminator/plugins/distro/base.py
@@ -27,7 +27,7 @@ import abc
 import logging
 
 from aminator.plugins.base import BasePlugin
-
+from aminator.util.linux import short_circuit_files, rewire_files
 
 __all__ = ('BaseDistroPlugin',)
 log = logging.getLogger(__name__)
@@ -54,3 +54,39 @@ class BaseDistroPlugin(BasePlugin):
     def __call__(self, mountpoint):
         self._mountpoint = mountpoint
         return self
+
+    def _deactivate_provisioning_service_block(self):
+        """
+        Prevent packages installing the chroot from starting
+        For RHEL-like systems, we can use short_circuit which replaces the service call with /bin/true
+        """
+        config = self._config.plugins[self.full_name]
+        files = config.get('short_circuit_files', [])
+        if files:
+            if not short_circuit_files(self._mountpoint, files):
+                log.critical('Unable to short circuit {0} to {1}')
+                return False
+            else:
+                log.debug('Files short-circuited successfully')
+                return True
+        else:
+            log.debug('No short circuit files configured')
+            return True
+
+    def _activate_provisioning_service_block(self):
+        """
+        Enable service startup so that things work when the AMI starts
+        For RHEL-like systems, we undo the short_circuit
+        """
+        config = self._config.plugins[self.full_name]
+        files = config.get('short_circuit_files', [])
+        if files:
+            if not rewire_files(self._mountpoint, files):
+                log.critical('Unable to rewire {0} to {1}')
+                return False
+            else:
+                log.debug('Files rewired successfully')
+                return True
+        else:
+            log.debug('No short circuit files configured, no rewiring done')
+        return True

--- a/aminator/plugins/distro/debian.py
+++ b/aminator/plugins/distro/debian.py
@@ -45,7 +45,9 @@ class DebianDistroPlugin(BaseLinuxDistroPlugin):
         Prevent packages installing in the chroot from starting
         For debian based distros, we add /usr/sbin/policy-rc.d
         """
-
+        if not super(DebianDistroPlugin, self)._deactivate_provisioning_service_block():
+            return False
+        
         config = self._config.plugins[self.full_name]
         path = self._mountpoint + config.get('policy_file_path', '')
         filename = path + "/" + config.get('policy_file')
@@ -68,6 +70,9 @@ class DebianDistroPlugin(BaseLinuxDistroPlugin):
         """
         Remove policy-rc.d file so that things start when the AMI launches
         """
+        if not super(DebianDistroPlugin, self)._activate_provisioning_service_block():
+            return False
+
         config = self._config.plugins[self.full_name]
 
         policy_file = self._mountpoint + "/" + config.get('policy_file_path', '') + "/" + \

--- a/aminator/plugins/distro/default_conf/aminator.plugins.distro.debian.yml
+++ b/aminator/plugins/distro/default_conf/aminator.plugins.distro.debian.yml
@@ -1,5 +1,7 @@
 enabled: true
 short_circuit: true
+short_circuit_files:
+  - /usr/sbin/service
 
 # fstab-esque list of mounts for a chroot environment. ordered.
 # [device, type, mount point, options]

--- a/aminator/plugins/distro/redhat.py
+++ b/aminator/plugins/distro/redhat.py
@@ -26,7 +26,6 @@ basic redhat distro
 import logging
 
 from aminator.plugins.distro.linux import BaseLinuxDistroPlugin
-from aminator.util.linux import short_circuit_files, rewire_files
 
 __all__ = ('RedHatDistroPlugin',)
 log = logging.getLogger(__name__)
@@ -40,37 +39,7 @@ class RedHatDistroPlugin(BaseLinuxDistroPlugin):
     _name = 'redhat'
 
     def _deactivate_provisioning_service_block(self):
-        """
-        Prevent packages installing the chroot from starting
-        For RHEL-like systems, we can use short_circuit which replaces the service call with /bin/true
-        """
-        config = self._config.plugins[self.full_name]
-        files = config.get('short_circuit_files', [])
-        if files:
-            if not short_circuit_files(self._mountpoint, files):
-                log.critical('Unable to short circuit {0} to {1}')
-                return False
-            else:
-                log.debug('Files short-circuited successfully')
-                return True
-        else:
-            log.debug('No short circuit files configured')
-            return True
+        return super(RedHatDistroPlugin, self)._deactivate_provisioning_service_block()
 
     def _activate_provisioning_service_block(self):
-        """
-        Enable service startup so that things work when the AMI starts
-        For RHEL-like systems, we undo the short_circuit
-        """
-        config = self._config.plugins[self.full_name]
-        files = config.get('short_circuit_files', [])
-        if files:
-            if not rewire_files(self._mountpoint, files):
-                log.critical('Unable to rewire {0} to {1}')
-                return False
-            else:
-                log.debug('Files rewired successfully')
-                return True
-        else:
-            log.debug('No short circuit files configured, no rewiring done')
-        return True
+        return super(RedHatDistroPlugin, self)._activate_provisioning_service_block()


### PR DESCRIPTION
need to short circuit /usr/sbin/service on ubuntu to prevent services from automatically starting at bake time during package post install
