### PR TITLE
set max delay for exponential delay on snapshot monitoring

### DIFF
--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -260,11 +260,13 @@ class EC2CloudPlugin(BaseCloudPlugin):
         obj.update()
         classname = obj.__class__.__name__
         if classname in ('Snapshot', 'Volume'):
+            if classname == 'Snapshot':
+                log.debug("Snapshot {0} state: {1}, progress: {2}".format(obj.id, obj.status, obj.progress))
             return obj.status == state
         else:
             return obj.state == state
 
-    @retry(VolumeException, tries=600, delay=0.5, backoff=1.5, logger=log)
+    @retry(VolumeException, tries=600, delay=0.5, backoff=1.5, logger=log, maxdelay=10)
     def _wait_for_state(self, resource, state):
         if self._state_check(resource, state):
             log.debug('{0} reached state {1}'.format(resource.__class__.__name__, state))

--- a/aminator/util/__init__.py
+++ b/aminator/util/__init__.py
@@ -34,7 +34,7 @@ from decorator import decorator
 log = logging.getLogger(__name__)
 
 
-def retry(ExceptionToCheck=None, tries=3, delay=0.5, backoff=1, logger=None):
+def retry(ExceptionToCheck=None, tries=3, delay=0.5, backoff=1, logger=None, maxdelay=None):
     """
     Retries a function or method until it returns True.
 
@@ -59,6 +59,8 @@ def retry(ExceptionToCheck=None, tries=3, delay=0.5, backoff=1, logger=None):
                 sleep(_delay)
                 _tries -= 1
                 _delay *= backoff
+                if maxdelay and _delay > maxdelay:
+                    _delay = maxdelay
         return f(*args, **kwargs)
     return _retry
 


### PR DESCRIPTION
The exponential delay quickly goes into multiple minute delays when waiting for completion, so set an upper bound of 10s so we continue to poll at a reasonable frequency.

Also log progress for snapshots so we can see when it starts (progress value changes from "None" to some integer value).
