### PR TITLE
fix for PR#199

### DIFF
--- a/aminator/plugins/finalizer/tagging_s3.py
+++ b/aminator/plugins/finalizer/tagging_s3.py
@@ -164,10 +164,7 @@ class TaggingS3FinalizerPlugin(TaggingBaseFinalizerPlugin):
     def finalize(self):
         log.info('Finalizing image')
         context = self._config.context
-        if "name" not in context.ami:
-            log.warn("Skipping finalize for ami without name")
-            return False
-            
+
         self._set_metadata()
 
         ret = self._copy_volume()


### PR DESCRIPTION
 context.ami.name can never be empty at this point, we just need to deal with failed provisioning at **exit**
