### PR TITLE
fix EXDEV error when backing up provision files

### DIFF
--- a/aminator/util/linux.py
+++ b/aminator/util/linux.py
@@ -371,9 +371,12 @@ def install_provision_config(src, dstpath, backup_ext='_aminator'):
                                 # need to copy across devices
                                 if os.path.isdir(dst):
                                     shutil.copytree(dst, backup, symlinks=True)
+                                    shutil.rmtree(dst)
                                 elif os.path.islink(dst):
                                     link = os.readlink(dst)
+                                    os.remove(dst)
                                     os.symlink(link, backup)
+                                    
                     elif os.path.isfile(dst):
                         shutil.copy(dst,backup)
                 except Exception:


### PR DESCRIPTION
ran into edge case with the docker plugin that fails to backup provision files due to an EXDEV exception.
