### PR TITLE
Use -f instead of --fix-missing to install the dependencies for the target package

### DIFF
--- a/aminator/plugins/provisioner/apt.py
+++ b/aminator/plugins/provisioner/apt.py
@@ -92,10 +92,10 @@ class AptProvisionerPlugin(BaseProvisionerPlugin):
         dpkg_ret = cls.dpkg_install(package)
         if not dpkg_ret.success:
             log.debug('failure:{0.command} :{0.std_err}'.format(dpkg_ret.result))
-            apt_ret = cls.apt_get_install('--fix-missing')
-            if not apt_ret.success:
-                log.debug('failure:{0.command} :{0.std_err}'.format(apt_ret.result))
-            return apt_ret
+            apt_fix_broken_ret = cls.apt_get_install('-f')
+            if not apt_fix_broken_ret.success:
+                log.debug('failure:{0.command} :{0.std_err}'.format(apt_fix_broken_ret.result))
+            return apt_fix_broken_ret
         return dpkg_ret
     
     @staticmethod


### PR DESCRIPTION
I understand that running "apt-get install -y --fix-missing" was intended to fix dependencies that were not installed during the dpkg install, however, --fix-missing is not working in this capacity. Instead I offer the use of '-f' which has gotten me some mileage in facilitating the install of the missing dependencies along with the package that required them. Feel free to shoot me down; I am curious to know if I may be using aminator incorrectly for installing package dependencies.
