### PR TITLE
add requirements for rpm build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -79,3 +79,6 @@ aminator.plugins.finalizer =
 
 aminator.plugins.metrics =
     logger = aminator.plugins.metrics.logger:LoggerMetricsPlugin
+
+[bdist_rpm]
+requires = python-boto >= 2.7 python-bunch python-decorator python-logutils python-pyyaml python-requests python-stevedore python-simplejson


### PR DESCRIPTION
I would like to get rpm packages from setup.py bdist_rpm containing all required rpm dependencies for aminator. Could be nice for some others.
