### PR TITLE
Add --partition parameter to allow mounting of partitioned volumes

### DIFF
--- a/aminator/plugins/blockdevice/base.py
+++ b/aminator/plugins/blockdevice/base.py
@@ -39,7 +39,10 @@ class BaseBlockDevicePlugin(BasePlugin):
     """
     __metaclass__ = abc.ABCMeta
     _entry_point = 'aminator.plugins.blockdevice'
-    partition = None
+
+    def __init__(self, *args, **kwargs):
+        self.partition = None
+        super(BasePlugin, self).__init__(*args, **kwargs)
     
     @abc.abstractmethod
     def __enter__(self):

--- a/aminator/plugins/blockdevice/base.py
+++ b/aminator/plugins/blockdevice/base.py
@@ -41,8 +41,8 @@ class BaseBlockDevicePlugin(BasePlugin):
     _entry_point = 'aminator.plugins.blockdevice'
 
     def __init__(self, *args, **kwargs):
-        self.partition = None
         super(BasePlugin, self).__init__(*args, **kwargs)
+        self.partition = None
     
     @abc.abstractmethod
     def __enter__(self):

--- a/aminator/plugins/blockdevice/base.py
+++ b/aminator/plugins/blockdevice/base.py
@@ -39,7 +39,8 @@ class BaseBlockDevicePlugin(BasePlugin):
     """
     __metaclass__ = abc.ABCMeta
     _entry_point = 'aminator.plugins.blockdevice'
-
+    partition = None
+    
     @abc.abstractmethod
     def __enter__(self):
         return self

--- a/aminator/plugins/blockdevice/linux.py
+++ b/aminator/plugins/blockdevice/linux.py
@@ -47,8 +47,6 @@ class LinuxBlockDevicePlugin(BaseBlockDevicePlugin):
     def configure(self, config, parser):
         super(LinuxBlockDevicePlugin, self).configure(config, parser)
 
-        block_config = self._config.plugins[self.full_name]
-
         if self._config.lock_dir.startswith(('/', '~')):
             self._lock_dir = os.path.expanduser(self._config.lock_dir)
         else:
@@ -56,24 +54,8 @@ class LinuxBlockDevicePlugin(BaseBlockDevicePlugin):
 
         self._lock_file = self.__class__.__name__
 
-        majors = block_config.device_letters
-        self._device_prefix = native_device_prefix(block_config.device_prefixes)
-
-        context = self._config.context
-
-        if "partition" in context.ami:
-            device_format = '/dev/{0}{1}'
-
-            self._allowed_devices = [device_format.format(self._device_prefix, major, minor)
-                                     for major in majors]
-            self.partition = context.ami['partition']
-
-        else:
-            device_format = '/dev/{0}{1}{2}'
-
-            self._allowed_devices = [device_format.format(self._device_prefix, major, minor)
-                                     for major in majors
-                                     for minor in xrange(1, 16)]
+        self._allowed_devices = None
+        self._device_prefix = None
 
 
     def add_plugin_args(self, *args, **kwargs):
@@ -97,6 +79,31 @@ class LinuxBlockDevicePlugin(BaseBlockDevicePlugin):
         self.release_dev(self._dev)
         return False
 
+    def _setup_allowed_devices(self):
+        if all((self._device_prefix, self._allowed_devices)):
+            return
+
+        block_config = self._config.plugins[self.full_name]
+        majors = block_config.device_letters
+
+        self._device_prefix = native_device_prefix(block_config.device_prefixes)
+
+        context = self._config.context
+
+        if "partition" in context.ami:
+            device_format = '/dev/{0}{1}'
+
+            self._allowed_devices = [device_format.format(self._device_prefix, major)
+                                     for major in majors]
+            self.partition = context.ami['partition']
+
+        else:
+            device_format = '/dev/{0}{1}{2}'
+
+            self._allowed_devices = [device_format.format(self._device_prefix, major, minor)
+                                     for major in majors
+                                     for minor in xrange(1, 16)]
+
     def allocate_dev(self):
         context = self._config.context
         if "block_device" in context.ami:
@@ -113,6 +120,7 @@ class LinuxBlockDevicePlugin(BaseBlockDevicePlugin):
     @raises("aminator.blockdevice.linux.find_available_dev.error")
     def find_available_dev(self):
         log.info('Searching for an available block device')
+        self._setup_allowed_devices()
         for dev in self._allowed_devices:
             log.debug('checking if device {0} is available'.format(dev))
             device_lock = os.path.join(self._lock_dir, os.path.basename(dev))

--- a/aminator/plugins/volume/linux.py
+++ b/aminator/plugins/volume/linux.py
@@ -59,7 +59,13 @@ class LinuxVolumePlugin(BaseVolumePlugin):
             os.makedirs(self._mountpoint)
 
         if not mounted(self._mountpoint):
-            mountspec = MountSpec(self._dev, None, self._mountpoint, None)
+            #Handle optional partition
+            dev = self._dev
+            if self._blockdevice.partition is not None:
+                dev = '{0}{1}'.format(dev,self._blockdevice.partition)
+            
+            mountspec = MountSpec(dev, None, self._mountpoint, None)
+
             result = mount(mountspec)
             if not result.success:
                 msg = 'Unable to mount {0.dev} at {0.mountpoint}: {1}'.format(mountspec, result.result.std_err)


### PR DESCRIPTION
This pull adds a --partition parameter to the linux block device plugin to facilitate mounting of volumes with partition tables. It also adds in proper handling of partitioned volumes to the linux volume plugin. It's currently being used in deployment to create HVM AMI's with the ansible and yum provisioners.

This follows the general concept outlined by @mtripoli in issue https://github.com/Netflix/aminator/issues/59

Usage example:
```
aminate -e ec2_ansible_amzn -n my_ami_name --partition 1 --vm-type hvm -B my-ami-id my/playbook.yml --debug
```
