### PR TITLE
Advanced AMI block device mapping support

### DIFF
--- a/aminator/plugins/finalizer/tagging_ebs.py
+++ b/aminator/plugins/finalizer/tagging_ebs.py
@@ -52,15 +52,8 @@ class TaggingEBSFinalizerPlugin(TaggingBaseFinalizerPlugin):
 
         tagging.add_argument('--ami-block-device-map',dest='ami_block_device_map',
                             action=conf_action(context.ami),
-                            help='Optionally specify a block device mapping to use for this AMI. Expects json either formats \
-                            ["device_name","ephemeral_name"]\
-                            Example: ["/dev/sdf","ephemeral0"]\
-                            \
-                            Can also accept a dictionary of values, for more details about possible values and combinations \
-                            please see http://boto.readthedocs.org/en/latest/ref/ec2.html#boto.ec2.blockdevicemapping.BlockDeviceType \
-                            \
-                            ["device_name",{"ephemeral_name":..,"no_device":..,"volume_id"..,"snapshot_id":..,"status":..,"attach_time":..,"delete_on_termination":...,"size":..,"volume_type":..,"iops":..}] \
-                            Example: ["/dev/sdf",{"delete_on_termination":false,"size":100,"volume_type":"gp2"}]')
+                            help='Optionally specify a block device mapping to use for this AMI. \
+                            For usage see https://github.com/willtrking/aminator/wiki/Block-device-mapping-examples')
 
     def _set_metadata(self):
         super(TaggingEBSFinalizerPlugin, self)._set_metadata()


### PR DESCRIPTION
This commit would add in granular AMI device mapping support to the ec2 cloud plugin and tagging_ebs finalizer. It is backwards compatible with existing ami block device mapping options. This is currently in use spinning up SSD AMI's in combination with my previous pull request https://github.com/Netflix/aminator/pull/207

Allowing definition of a different root device with
```
--ami-root-device
```

Allowing granular definition of the AMI block device mapping with
```
--ami-block-device-map
```
I've written a (very) brief piece on the block device mapping support [here] (https://github.com/willtrking/aminator/wiki/Block-device-mapping-examples)

This is a fully featured example of creating a partitioned HVM AMI with a seperate root device and block device mapping with the ansible provisioner
```
aminate -e ec2_ansible_amzn -n TEST_APP_1 --ami-root-device '/dev/sda1' --ami-block-device-map '[["/dev/sda1",{"volume_type":"gp2","size":8}]]' --partition 1 --vm-type hvm -B my_private_ami app-webapp/development.yml --debug
```