### PR TITLE
Logging AMI ID

### DIFF
--- a/aminator/core.py
+++ b/aminator/core.py
@@ -69,4 +69,9 @@ class Aminator(object):
             ok = env.provision()
             if ok:
                 log.info('Amination complete!')
+                _ami_id = env.get_registered_ami_id()
+                if not _ami_id:
+                    log.info('AMI: NULL')
+                else:
+                    log.info('AMI: {0}'.format(os.environ['AMINATOR_REGISTERED_AMI_ID']))
         return 0 if ok else 1

--- a/aminator/environment.py
+++ b/aminator/environment.py
@@ -67,7 +67,12 @@ class Environment(object):
                         if not success:
                             log.critical('Finalizing failed!')
                             return False
+                self._registered_ami_id = cloud.get_registered_ami_id()
+
         return True
+
+    def get_registered_ami_id(self):
+        return self._registered_ami_id
 
     def __enter__(self):
         return self
@@ -82,4 +87,5 @@ class Environment(object):
         self._name = self._config.context.get('environment', self._config.environments.default)
         self._config.context['environment'] = self._name
         self._attach_plugins()
+        self._registered_ami_id = None
         return self

--- a/aminator/plugins/cloud/base.py
+++ b/aminator/plugins/cloud/base.py
@@ -87,6 +87,14 @@ class BaseCloudPlugin(BasePlugin):
         """ consumes tags and applies them to objects """
 
     @abc.abstractmethod
+    def save_registered_ami_id(self, *args, **kwargs):
+        """ Saves the registered AMI ID if registration was successful """
+
+    @abc.abstractmethod
+    def get_registered_ami_id(self, *args, **kwargs):
+        """ Get the registered AMI ID saved with 'save_registered_ami_id' """
+
+    @abc.abstractmethod
     def register_image(self, *args, **kwargs):
         """ Instructs the cloud provider to register a finalized image for launching """
 

--- a/aminator/plugins/cloud/base.py
+++ b/aminator/plugins/cloud/base.py
@@ -87,11 +87,11 @@ class BaseCloudPlugin(BasePlugin):
         """ consumes tags and applies them to objects """
 
     @abc.abstractmethod
-    def save_registered_ami_id(self, *args, **kwargs):
+    def save_registered_ami_id(self, ami_id):
         """ Saves the registered AMI ID if registration was successful """
 
     @abc.abstractmethod
-    def get_registered_ami_id(self, *args, **kwargs):
+    def get_registered_ami_id(self):
         """ Get the registered AMI ID saved with 'save_registered_ami_id' """
 
     @abc.abstractmethod

--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -333,7 +333,7 @@ class EC2CloudPlugin(BaseCloudPlugin):
         log.debug('{0} not stale, using'.format(dev))
         return False
 
-    def save_registered_ami_id(self,ami_id):
+    def save_registered_ami_id(self, ami_id):
         environ['AMINATOR_REGISTERED_AMI_ID'] = str(ami_id)
 
     def get_registered_ami_id(self):

--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -333,6 +333,14 @@ class EC2CloudPlugin(BaseCloudPlugin):
         log.debug('{0} not stale, using'.format(dev))
         return False
 
+    def save_registered_ami_id(self,ami_id):
+        environ['AMINATOR_REGISTERED_AMI_ID'] = str(ami_id)
+
+    def get_registered_ami_id(self):
+        if 'AMINATOR_REGISTERED_AMI_ID' in environ:
+            return environ['AMINATOR_REGISTERED_AMI_ID']
+        return None
+
     @registration_retry(tries=3, delay=1, backoff=1)
     def _register_image(self, **ami_metadata):
         context = self._config.context
@@ -353,6 +361,7 @@ class EC2CloudPlugin(BaseCloudPlugin):
                     else:
                         raise e
             log.info('AMI registered: {0} {1}'.format(ami.id, ami.name))
+            self.save_registered_ami_id(ami.id)
             context.ami.image = self._ami = ami
             return True
 


### PR DESCRIPTION
This pull would add in methods to both save and read the registered AMI ID. It also uses those methods to log the AMI ID as the last line of logging output, instead of 'Amination Complete!' This allows for the AMI ID to be more easily machine readable. Here's a bash example that does just that using tail and awk.

```
aminate ....args... 2> stderr.log >stdout.log
LAST_LINE=$(tail -n 1 stdout.log)
AMI_ID=$(echo $LAST_LINE | awk '{print substr($0,index($0,"AMI: ")+5)}')
```

Sorry to keep inundating you guys with these requests