### PR TITLE
change from aptitude hold to aptitude install

### DIFF
--- a/aminator/plugins/provisioner/aptitude.py
+++ b/aminator/plugins/provisioner/aptitude.py
@@ -51,7 +51,7 @@ class AptitudeProvisionerPlugin(AptProvisionerPlugin):
         pkgname = re.sub(r'_.*$', "", basename(package))
         if not dpkg_ret.success:
             log.debug('failure:{0.command} :{0.std_err}'.format(dpkg_ret.result))
-            aptitude_ret = cls.aptitude("install", pkgname)
+            aptitude_ret = cls.aptitude("hold", pkgname)
             if not aptitude_ret.success:
                 log.debug('failure:{0.command} :{0.std_err}'.format(aptitude_ret.result))
             query_ret = super(AptitudeProvisionerPlugin,cls).deb_query(pkgname, "${Status}", local=False)


### PR DESCRIPTION
the dependency resolves for hold are crazy, install is more sane.  Both require a config file  `/etc/apt/apt.conf.d/00aptitude-sane-resolve.conf` with the contents:

```
Aptitude {
    ProblemResolver {
        SolutionCost "priority, removals, canceled-actions";
    };
};
```

otherwise aptitude will find the "best" resolve strategy is to remove the package you want installed if it has any dependencies.