### PR TITLE
make aptitude provisioner verify correct version was installed

### DIFF
--- a/aminator/plugins/provisioner/aptitude.py
+++ b/aminator/plugins/provisioner/aptitude.py
@@ -69,11 +69,14 @@ class AptitudeProvisionerPlugin(AptProvisionerPlugin):
             aptitude_ret = cls.aptitude("install", "{}={}".format(pkgname, pkgver))
             if not aptitude_ret.success:
                 log.debug('failure:{0.command} :{0.std_err}'.format(aptitude_ret.result))
-            query_ret = super(AptitudeProvisionerPlugin,cls).deb_query(pkgname, "${Status}", local=False)
+            query_ret = super(AptitudeProvisionerPlugin,cls).deb_query(pkgname, "${Status} ${Version}", local=False)
             if not query_ret.success:
                 log.debug('failure:{0.command} :{0.std_err}'.format(query_ret.result))
             if "install ok installed" not in query_ret.result.std_out:
                 raise RuntimeError("package {} failed to be installed.  dpkg status: {}".format(pkgname, query_ret.result.std_out))
+            installed_version = query_ret.result.std_out.split()[-1].strip()
+            if installed_version != pkgver:
+                raise RuntimeError("package {} failed to be installed. requested version {}, aptitude installed {}".format(pkgname, pkgver, installed_version))
             return query_ret
         return dpkg_ret
 


### PR DESCRIPTION
Aptitude likes to occasionally select solutions that involve downgrading the package requested. We can fix this more directly by tuning the ProblemResolver, but this provides a safeguard that fails the bake if aptitude does install the wrong package version in the end. It does NOT currently do any checking of dependencies installed, just the main requested package.

cc @coryb @kvick 