### PR TITLE
change deb local install to delay metadata refresh until after dpkg -i

### DIFF
--- a/aminator/plugins/provisioner/apt.py
+++ b/aminator/plugins/provisioner/apt.py
@@ -47,23 +47,15 @@ class AptProvisionerPlugin(BaseProvisionerPlugin):
     """
     _name = 'apt'
 
-    def _refresh_repo_metadata(self):
-        return self.apt_get_update()
-
     @cmdsucceeds("aminator.provisioner.apt.provision_package.count")
     @cmdfails("aminator.provisioner.apt.provision_package.error")
     @lapse("aminator.provisioner.apt.provision_package.duration")
     def _provision_package(self):
-        result = self._refresh_repo_metadata()
-        if not result.success:
-            log.critical('Repo metadata refresh failed: {0.std_err}'.format(result.result))
-            return result
         context = self._config.context
         os.environ['DEBIAN_FRONTEND'] = 'noninteractive'
-        if context.package.get('local_install', False):
-            return self.apt_get_localinstall(context.package.arg)
-        else:
-            return self.apt_get_install(context.package.arg)
+        return self.install(context.package.arg,
+                            local_install=context.package.get('local_install', False))
+
 
     def _store_package_metadata(self):
         context = self._config.context
@@ -89,19 +81,37 @@ class AptProvisionerPlugin(BaseProvisionerPlugin):
 
     @staticmethod
     def dpkg_install(package):
-        return monitor_command(['dpkg', '-i', package])
+        dpkg_result = monitor_command(['dpkg', '-i', package])
+        if not dpkg_result.success:
+            log.debug('failure:{0.command} :{0.std_err}'.format(dpkg_ret.result))
+        return dpkg_result
 
     @classmethod
-    def apt_get_localinstall(cls, package):
+    def _fix_localinstall_deps(cls, package):
+        # use apt-get to resolve dependencies after a dpkg -i
+        fix_deps_result = cls.apt_get_install('--fix-missing')
+        if not fix_deps_result.success:
+            log.debug('failure:{0.command} :{0.std_err}'.format(fix_deps_result.result))
+        return fix_deps_result
+
+    @classmethod
+    def _localinstall(cls, package):
         """install deb file with dpkg then resolve dependencies
         """
         dpkg_ret = cls.dpkg_install(package)
         if not dpkg_ret.success:
-            log.debug('failure:{0.command} :{0.std_err}'.format(dpkg_ret.result))
-            apt_ret = cls.apt_get_install('--fix-missing')
-            if not apt_ret.success:
-                log.debug('failure:{0.command} :{0.std_err}'.format(apt_ret.result))
-            return apt_ret
+            # expected when package has dependencies that are not installed
+            update_metadata_result = self.apt_get_update()
+            if not update_metadata_result.success:
+                errmsg = 'Repo metadata refresh failed: {0.std_err}'
+                errmsg = errmsg.format(update_metadata_result.result)
+                return update_metadata_result
+            log.info("Installing dependencies for package {0}".format(package))
+            fix_deps_result = cls._fix_localinstall_deps(package)
+            if not fix_deps_result.success:
+                log.critical("Error encountered installing dependencies: "
+                             "{0.std_err}".format(fix_deps_result.result))
+            return fix_deps_result
         return dpkg_ret
 
     @staticmethod
@@ -113,15 +123,19 @@ class AptProvisionerPlugin(BaseProvisionerPlugin):
             cmd = 'dpkg-query -W'.split()
             cmd.append('-f={0}'.format(queryformat))
         cmd.append(package)
-        return monitor_command(cmd)
+        deb_query_result = monitor_command(cmd)
+        if not deb_query_result.success:
+            log.debug('failure:{0.command} :{0.std_err}'.format(deb_query_result.result))
+        return deb_query_result
 
     @cmdsucceeds("aminator.provisioner.apt.apt_get_update.count")
     @cmdfails("aminator.provisioner.apt.apt_get_update.error")
     @timer("aminator.provisioner.apt.apt_get_update.duration")
     @retry(ExceptionToCheck=AptProvisionerUpdateException, tries=5, delay=1,
            backoff=0.5, logger=log)
-    def apt_get_update(self):
-        self.apt_get_clean()
+    @classmethod
+    def apt_get_update(cls):
+        cls.apt_get_clean()
         dpkg_update = monitor_command(['apt-get', 'update'])
         if not dpkg_update.success:
             log.debug('failure: {0.command} :{0.std_err}'.format(dpkg_update.result))
@@ -134,9 +148,33 @@ class AptProvisionerPlugin(BaseProvisionerPlugin):
     def apt_get_clean():
         return monitor_command(['apt-get', 'clean'])
 
+    @staticmethod
+    def apt_get_install(*options):
+        install_result = monitor_command(['apt-get', '-y', 'install'] + options)
+        if not install_result.success:
+            log.debug('failure:{0.command} :{0.std_err}'.format(install_result.result))
+        return install_result
+
     @classmethod
-    def apt_get_install(cls, package):
-        return monitor_command(['apt-get', '-y', 'install', package])
+    def _install(cls, package):
+        return cls.apt_get_install(package)
+
+    @classmethod
+    def install(cls, package, local_install=False):
+        if local_install:
+            install_result = cls._localinstall(package)
+        else:
+            update_metadata_result = cls._refresh_repo_metadata()
+            if not update_metadata_result.success:
+                errmsg = 'Repo metadata refresh failed: {0.std_err}'
+                errmsg = errmsg.format(update_metadata_result.result)
+                return update_metadata_result
+            install_result = cls._install(package)
+        if not install_result.success:
+            errmsg = 'Error installing package {0}: {1.std_err}'
+            errmsg = errmsg.format(package, install_result.result)
+            log.critical(errmsg)
+        return install_result
 
     @classmethod
     def deb_package_metadata(cls, package, queryformat, local=False):

--- a/aminator/plugins/provisioner/aptitude.py
+++ b/aminator/plugins/provisioner/aptitude.py
@@ -43,11 +43,16 @@ import logging
 from os.path import basename
 import re
 
+from aminator.exceptions import ProvisionException
 from aminator.plugins.provisioner.apt import AptProvisionerPlugin
 from aminator.util.linux import monitor_command
 
 __all__ = ('AptitudeProvisionerPlugin',)
 log = logging.getLogger(__name__)
+
+
+class AptitudeInstallException(ProvisionException):
+    pass
 
 
 class AptitudeProvisionerPlugin(AptProvisionerPlugin):
@@ -59,47 +64,59 @@ class AptitudeProvisionerPlugin(AptProvisionerPlugin):
 
     # overload this method to call aptitude instead.
     @classmethod
-    def apt_get_localinstall(cls, package):
-        """install deb file with dpkg then resolve dependencies
-        """
-        dpkg_ret = cls.dpkg_install(package)
+    def _fix_localinstall_deps(cls, package):
+        # use aptitude and its solver to resolve dependencies after a dpkg -i
         pkgname, _, _ = basename(package).split('_')
-        if not dpkg_ret.success:
-            # figure out the version via dpkg rather than parsing it out of the file name
-            # in case there is an epoch in the version
-            query_ret = super(AptitudeProvisionerPlugin,cls).deb_query(package, "${Version}", local=True)
-            if not query_ret.success:
-                log.debug('failure:{0.command} :{0.std_err}'.format(query_ret.result))
-            pkgver = query_ret.result.std_out
 
-            log.debug('failure:{0.command} :{0.std_err}'.format(dpkg_ret.result))
-            aptitude_ret = cls.aptitude("install", "{}={}".format(pkgname, pkgver))
-            if not aptitude_ret.success:
-                log.debug('failure:{0.command} :{0.std_err}'.format(aptitude_ret.result))
-            query_ret = super(AptitudeProvisionerPlugin,cls).deb_query(pkgname, "${Status} ${Version}", local=False)
-            if not query_ret.success:
-                log.debug('failure:{0.command} :{0.std_err}'.format(query_ret.result))
-            if "install ok installed" not in query_ret.result.std_out:
-                raise RuntimeError("package {} failed to be installed.  dpkg status: {}".format(pkgname, query_ret.result.std_out))
-            installed_version = query_ret.result.std_out.split()[-1].strip()
-            if installed_version != pkgver:
-                raise RuntimeError("package {} failed to be installed. requested version {}, aptitude installed {}".format(pkgname, pkgver, installed_version))
-            return query_ret
-        return dpkg_ret
+        # figure out the version via dpkg rather than parsing it out of the file name
+        # in case there is an epoch in the version
+        version_query_ret = cls.deb_query(package, "${Version}", local=True)
+        if not version_query_ret.success:
+            log.critical("Unable to query version for package {0}".format(package))
+            return version_query_ret
+        pkgver = version_query_ret.result.std_out
+
+        aptitude_ret = cls.aptitude("install", "{0}={1}".format(pkgname, pkgver))
+        if not aptitude_ret.success:
+            log.critical("Error encountered resolving dependencies for package {0}: "
+                         "{1.std_err}".format(package, aptitude_ret.result))
+            return aptitude_ret
+
+        install_query_ret = cls.deb_query(pkgname, "${Status} ${Version}", local=False)
+        if not install_query_ret.success:
+            log.critical("Error querying installation status for package {0}: "
+                         "{1.std_err}".format(package, install_query_ret.result))
+            return install_query_ret
+
+        if "install ok installed" not in install_query_ret.result.std_out:
+            errmsg = "package {0} failed to be installed. dpkg status: {1.std_out}"
+            errmsg = errmsg.format(package, install_query_ret.result)
+            raise AptitudeInstallException(errmsg)
+
+        installed_version = install_query_ret.result.std_out.split()[-1].strip()
+        if installed_version != pkgver:
+            errmsg = "package {0} failed to be installed. requested {1}, installed {2}"
+            errmsg = errmsg.format(pkgname, pkgver, installed_version)
+            raise AptitudeInstallException(errmsg)
+
+        return install_query_ret
 
     @staticmethod
     def aptitude(operation, package):
-        return monitor_command(["aptitude", "--no-gui", "-y", operation, package])
+        aptitude_result = monitor_command(["aptitude", "--no-gui", "-y", operation, package])
+        if not aptitude_result.success:
+            log.debug('failure:{0.command} :{0.std_err}'.format(aptitude_result.result))
+        return aptitude_result
 
     # overload this method to call aptitude instead.  But aptitude will not exit with
     # an error code if it failed to install, so we double check that the package installed
     # with the dpkg-query command
     @classmethod
-    def apt_get_install(cls,package):
+    def _install(cls, package):
         aptitude_ret = cls.aptitude("install", package)
-        if not aptitude_ret.success:
-            log.debug('failure:{0.command} :{0.std_err}'.format(aptitude_ret.result))
         query_ret = cls.deb_query(package, '${Package}-${Version}')
         if not query_ret.success:
-            log.debug('failure:{0.command} :{0.std_err}'.format(query_ret.result))
+            errmsg = "Error installing package {0}: {1.std_err}"
+            errmsg = errmsg.format(package, query_ret.result)
+            log.critical(errmsg)
         return query_ret


### PR DESCRIPTION
Some refactoring/cleanup here to try to avoid some repetition, but the main change is having the apt and aptitude provisioners, when doing a local install, delay apt-get update until after dpkg -i and before the deps are fixed. This hack allows one to package an apt sources file in their package and have the repositories used for dependencies during the dep fixing phase.
cc @coryb @kvick 