### PR TITLE
Move stack traces into detailed debug logs

### DIFF
--- a/aminator/config.py
+++ b/aminator/config.py
@@ -169,7 +169,9 @@ def configure_datetime_logfile(config, handler):
         pkg = "{0}-{1}".format(os.path.basename(config.context.package.arg), randword(6))
         filename = os.path.join(config.log_root, filename_format.format(pkg, datetime.utcnow()))
     except IndexError:
-        log.exception("missing replacement fields in {0}'s filename_format")
+        errstr = 'Missing replacement fields in filename_format for handler {0}'.format(handler)
+        log.error(errstr)
+        log.debug(errstr, exc_info=True)
 
     # find handler amongst all the loggers and reassign the filename/stream
     for h in [x for l in logging.root.manager.loggerDict for x in logging.getLogger(l).handlers] + logging.root.handlers:

--- a/aminator/environment.py
+++ b/aminator/environment.py
@@ -74,7 +74,7 @@ class Environment(object):
 
     def __exit__(self, exc_type, exc_value, trc):
         if exc_type:
-            log.exception("Exception: {0}: {1}".format(exc_type.__name__, exc_value))
+            log.debug('Exception encountered in environment context manager', exc_info=(exc_type, exc_value, trc))
         return False
 
     def __call__(self, config, plugin_manager):

--- a/aminator/plugins/blockdevice/base.py
+++ b/aminator/plugins/blockdevice/base.py
@@ -51,7 +51,7 @@ class BaseBlockDevicePlugin(BasePlugin):
     @abc.abstractmethod
     def __exit__(self, typ, val, trc):
         if typ:
-            log.exception("Exception: {0}: {1}".format(typ.__name__, val))
+            log.debug('Exception encountered in block device plugin', exc_info=(typ, val, trc))
         return False
 
     def __call__(self, cloud):

--- a/aminator/plugins/blockdevice/linux.py
+++ b/aminator/plugins/blockdevice/linux.py
@@ -71,7 +71,8 @@ class LinuxBlockDevicePlugin(BaseBlockDevicePlugin):
 
     def __exit__(self, typ, val, trc):
         if typ:
-            log.exception("Exception: {0}: {1}".format(typ.__name__, val))
+            log.debug('Exception encountered in Linux block device plugin context manager',
+                      exc_info=(typ, val, trc))
         self.release_dev(self._dev)
         return False
 

--- a/aminator/plugins/blockdevice/null.py
+++ b/aminator/plugins/blockdevice/null.py
@@ -39,5 +39,6 @@ class NullBlockDevicePlugin(BaseBlockDevicePlugin):
 
     def __exit__(self, typ, val, trc):
         if typ:
-            log.exception("Exception: {0}: {1}".format(typ.__name__, val))
+            log.debug('Exception encountered in Null block device plugin',
+                      exc_info=(typ, val, trc))
         return False

--- a/aminator/plugins/cloud/base.py
+++ b/aminator/plugins/cloud/base.py
@@ -96,5 +96,6 @@ class BaseCloudPlugin(BasePlugin):
 
     def __exit__(self, typ, val, trc):
         if typ:
-            log.exception("Exception: {0}: {1}".format(typ.__name__, val))
+            log.debug('Exception encountered in Cloud plugin context manager',
+                      exc_info=(typ, val, trc))
         return False

--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -388,15 +388,18 @@ class EC2CloudPlugin(BaseCloudPlugin):
         try:
             instance = getattr(self, instance_var)
         except Exception:
-            log.exception('Unable to find local instance var {0}'.format(instance_var))
-            log.critical('Tagging failed')
+            errstr = 'Tagging failed: Unable to find local instance var {0}'.format(instance_var)
+            log.debug(errstr, exc_info=True)
+            log.critical(errstr)
             return False
         else:
             try:
                 self._connection.create_tags([instance.id], tags)
             except EC2ResponseError:
-                log.exception('Error creating tags for resource type {0}, id {1}'.format(resource_type, instance.id))
-                raise FinalizerException('Error creating tags for resource type {0}, id {1}'.format(resource_type, instance.id))
+                errstr = 'Error creating tags for resource type {0}, id {1}'
+                errstr = errstr.format(resource_type, instance.id)
+                log.critical(errstr)
+                raise FinalizerException(errstr)
             else:
                 log.debug('Successfully tagged {0}({1})'.format(resource_type, instance.id))
                 instance.update()

--- a/aminator/plugins/distro/base.py
+++ b/aminator/plugins/distro/base.py
@@ -48,7 +48,8 @@ class BaseDistroPlugin(BasePlugin):
     @abc.abstractmethod
     def __exit__(self, exc_type, exc_value, trace):
         if exc_type:
-            log.exception("Exception: {0}: {1}".format(exc_type.__name__, exc_value))
+            log.debug('Exception encountered in distro plugin context manager',
+                      exc_info=(exc_type, exc_value, trace))
         return False
 
     def __call__(self, mountpoint):

--- a/aminator/plugins/distro/linux.py
+++ b/aminator/plugins/distro/linux.py
@@ -201,7 +201,8 @@ class BaseLinuxDistroPlugin(BaseDistroPlugin):
 
     def __exit__(self, exc_type, exc_value, trace):
         if exc_type:
-            log.exception("Exception: {0}: {1}".format(exc_type.__name__, exc_value))
+            log.debug('Exception encountered in Linux distro plugin context manager',
+                      exc_info=(exc_type, exc_value, trace))
         if exc_type and self._config.context.get("preserve_on_error", False):
             return False
         if not self._teardown_chroot():

--- a/aminator/plugins/finalizer/base.py
+++ b/aminator/plugins/finalizer/base.py
@@ -51,7 +51,8 @@ class BaseFinalizerPlugin(BasePlugin):
 
     def __exit__(self, typ, val, trc):
         if typ:
-            log.exception("Exception: {0}: {1}".format(typ.__name__, val))
+            log.debug('Exception encountered in Finalizer plugin context manager',
+                      exc_info=(typ, val, trc))
         return False
 
     def __call__(self, cloud):

--- a/aminator/plugins/finalizer/tagging_base.py
+++ b/aminator/plugins/finalizer/tagging_base.py
@@ -75,7 +75,9 @@ class TaggingBaseFinalizerPlugin(BaseFinalizerPlugin):
                 context.ami.tags[tag] = config.tag_formats[tag].format(**metadata)
                 context.snapshot.tags[tag] = config.tag_formats[tag].format(**metadata)
             except KeyError as e:
-                log.exception("Tag format requires information not available in package metadata: {}".format(e.message))
+                errstr = 'Tag format requires information not available in package metadata: {0}'.format(e.message)
+                log.warn(errstr)
+                log.debug(errstr, exc_info=True)
                 # in case someone uses a tag format based on metadata not available
                 # in this package
                 continue
@@ -92,7 +94,9 @@ class TaggingBaseFinalizerPlugin(BaseFinalizerPlugin):
             try:
                 self._cloud.add_tags(resource)
             except FinalizerException:
-                log.exception('Error adding tags to {0}'.format(resource))
+                errstr = 'Error adding tags to {0}'.format(resource)
+                log.error(errstr)
+                log.debug(errstr, exc_info=True)
                 return False
             log.info('Successfully tagged {0}'.format(resource))
         log.info('Successfully tagged objects')
@@ -128,7 +132,8 @@ class TaggingBaseFinalizerPlugin(BaseFinalizerPlugin):
 
     def __exit__(self, exc_type, exc_value, trace):
         if exc_type:
-            log.exception("Exception: {0}: {1}".format(exc_type.__name__, exc_value))
+            log.debug('Exception encountered in tagging base finalizer context manager',
+                      exc_info=True)
         return False
 
     def __call__(self, cloud):

--- a/aminator/plugins/finalizer/tagging_s3.py
+++ b/aminator/plugins/finalizer/tagging_s3.py
@@ -211,12 +211,14 @@ class TaggingS3FinalizerPlugin(TaggingBaseFinalizerPlugin):
 
     def __exit__(self, exc_type, exc_value, trace):
         if exc_type:
-            log.exception("Exception: {0}: {1}".format(exc_type.__name__, exc_value))
+            log.debug('Exception encountered in tagging s3 finalizer context manager',
+                      exc_info=(exc_type, exc_value, trace))
         # delete tmpdir used by ec2-bundle-vol
         try:
             td = self.tmpdir()
             if isdir(td):
                 rmtree(td)
         except Exception:
-            log.exception("Failed to cleanup s3 bundle tmpdir")
+            log.debug('Exception encountered attempting to clean s3 bundle tmpdir',
+                      exc_info=True)
         return False

--- a/aminator/plugins/metrics/base.py
+++ b/aminator/plugins/metrics/base.py
@@ -77,5 +77,6 @@ class BaseMetricsPlugin(BasePlugin):
     def __exit__(self, exc_type, exc_value, trace):
         self.flush()
         if exc_type:
-            log.exception("Exception: {0}: {1}".format(exc_type.__name__, exc_value))
+            log.debug('Exception encountered in metrics plugin context manager',
+                      exc_info=(exc_type, exc_value, trace))
         return False

--- a/aminator/plugins/provisioner/base.py
+++ b/aminator/plugins/provisioner/base.py
@@ -174,7 +174,9 @@ class BaseProvisionerPlugin(BasePlugin):
             else:
                 self._move_pkg(context)
         except Exception:
-            log.exception('Error encountered while staging package')
+            errstr = 'Exception encountered while staging package'
+            log.critical(errstr)
+            log.debug(errstr, exc_info=True)
             return False
             # reset to chrooted file path
         context.package.arg = os.path.join(context.package.dir, context.package.file)

--- a/aminator/plugins/volume/base.py
+++ b/aminator/plugins/volume/base.py
@@ -50,7 +50,8 @@ class BaseVolumePlugin(BasePlugin):
     @abc.abstractmethod
     def __exit__(self, exc_type, exc_value, trace):
         if exc_type:
-            log.exception("Exception: {0}: {1}".format(exc_type.__name__, exc_value))
+            log.debug('Exception encountered in volume plugin context manager',
+                      exc_info=(exc_type, exc_value, trace))
         return False
 
     def __call__(self, cloud, blockdevice):

--- a/aminator/plugins/volume/linux.py
+++ b/aminator/plugins/volume/linux.py
@@ -94,7 +94,8 @@ class LinuxVolumePlugin(BaseVolumePlugin):
 
     def __exit__(self, exc_type, exc_value, trace):
         if exc_type:
-            log.exception("Exception: {0}: {1}".format(exc_type.__name__, exc_value))
+            log.debug('Exception encountered in linux volume plugin context manager',
+                      exc_info=(exc_type, exc_value, trace))
         if exc_type and self._config.context.get("preserve_on_error", False):
             return False
         self._unmount()

--- a/aminator/util/linux.py
+++ b/aminator/util/linux.py
@@ -225,7 +225,7 @@ class Chroot(object):
 
     def __exit__(self, typ, exc, trc):
         if typ:
-            log.exception("Exception: {0}: {1}".format(typ.__name__, exc))
+            log.debug('Exception encountered in Chroot', exc_info=(typ, exc, trc))
         log.debug('Leaving chroot')
         os.fchdir(self.real_root)
         os.chroot('.')
@@ -385,14 +385,18 @@ def install_provision_config(src, dstpath, backup_ext='_aminator'):
                     elif os.path.isfile(dst):
                         shutil.copy(dst, backup)
                 except Exception:
-                    log.exception('Error encountered while copying {0} to {1}'.format(dst, backup))
+                    errstr = 'Error encountered while copying {0} to {1}'.format(dst, backup)
+                    log.critical(errstr)
+                    log.debug(errstr, exc_info=True)
                     return False
             if os.path.isdir(src):
                 shutil.copytree(src, dst, symlinks=True)
             else:
                 shutil.copy(src, dst)
         except Exception:
-            log.exception('Error encountered while copying {0} to {1}'.format(src, dst))
+            errstr = 'Error encountered while copying {0} to {1}'.format(src, dst)
+            log.critical(errstr)
+            log.debug(errstr, exc_info=True)
             return False
         log.debug('{0} copied from aminator host to {1}'.format(src, dstpath))
         return True
@@ -419,7 +423,9 @@ def remove_provision_config(src, dstpath, backup_ext='_aminator'):
                     shutil.rmtree(dst)
                     log.debug('Provision config {0} removed'.format(dst))
             except Exception:
-                log.exception('Error encountered while removing {0}'.format(dst))
+                errstr='Error encountered while removing {0}'.format(dst)
+                log.critical(errstr)
+                log.debug(errstr, exc_info=True)
                 return False
 
         if os.path.isfile(backup) or os.path.islink(backup) or os.path.isdir(backup):
@@ -432,7 +438,9 @@ def remove_provision_config(src, dstpath, backup_ext='_aminator'):
         else:
             log.warn('No backup file {0} was found'.format(backup))
     except Exception:
-        log.exception('Error encountered while restoring {0} to {1}'.format(backup, dst))
+        errstr = 'Error encountered while restoring {0} to {1}'.format(backup, dst)
+        log.critical(errstr)
+        log.debug(errstr, exc_info=True)
         return False
     return True
 
@@ -454,7 +462,9 @@ def short_circuit(root, cmd, ext='short_circuit', dst='/bin/true'):
             os.symlink(dst, fullpath)
             log.debug('{0} linked to {1}'.format(fullpath, dst))
         except Exception:
-            log.exception('Error encountered while short circuiting {0} to {1}'.format(fullpath, dst))
+            errstr = 'Error encountered while short circuiting {0} to {1}'.format(fullpath, dst)
+            log.critical(errstr)
+            log.debug(errstr, exc_info=True)
             return False
         else:
             log.debug('short circuited {0} to {1}'.format(fullpath, dst))
@@ -480,7 +490,9 @@ def rewire(root, cmd, ext='short_circuit'):
             os.rename('{0}.{1}'.format(fullpath, ext), fullpath)
             log.debug('{0} rewired'.format(fullpath))
         except Exception:
-            log.exception('Error encountered while rewiring {0}'.format(fullpath))
+            errstr = 'Error encountered while rewiring {0}'.format(fullpath)
+            log.critical(errstr)
+            log.debug(errstr, exc_info=True)
             return False
         else:
             log.debug('rewired {0}'.format(fullpath))

--- a/aminator/util/linux.py
+++ b/aminator/util/linux.py
@@ -423,7 +423,7 @@ def remove_provision_config(src, dstpath, backup_ext='_aminator'):
                     shutil.rmtree(dst)
                     log.debug('Provision config {0} removed'.format(dst))
             except Exception:
-                errstr='Error encountered while removing {0}'.format(dst)
+                errstr = 'Error encountered while removing {0}'.format(dst)
                 log.critical(errstr)
                 log.debug(errstr, exc_info=True)
                 return False


### PR DESCRIPTION
We surface stack traces in the simple bakery log output which seems to overwhelm and confuse users. This changes usage of logging.exception to log.debug with exc_info set to True when encountered in a try/except and exc_info=(typ, val, trc) from the context manager when we exit a context manager due to an exception.

For generic context manager exits I simply shuffled the output to debug, but for regular try/catch exceptions, I paired the debug w/ stack trace with a warn, error, or critical log that will show up in the simple log output.

cc @coryb @kvick 