### PR TITLE
fix #234 - block device minor device number configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ nosetests.xml
 
 .*.pylint
 pylint/
+
+flake8/

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,4 +3,4 @@ validate:
 	virtualenv --no-site-packages flake8; \
 	flake8/bin/pip install flake8; \
 	export PATH=$$(pwd)/flake8/bin:$$PATH; \
-	flake8 -v --ignore=E501 aminator
+	flake8 -v aminator

--- a/aminator/plugins/blockdevice/default_conf/aminator.plugins.blockdevice.linux.yml
+++ b/aminator/plugins/blockdevice/default_conf/aminator.plugins.blockdevice.linux.yml
@@ -3,3 +3,6 @@ enabled: true
 device_prefixes: [xvd, sd]
 # think device_prefix + device letter (sda, sdb, xvda, etc)
 device_letters: 'fghijklmnop'
+# if aminating on a HVM instance, one cannot use minor device numbers for EBS
+# volumes. Set this to False to avoid using minor device numbers
+use_minor_device_numbers: true

--- a/aminator/plugins/blockdevice/linux.py
+++ b/aminator/plugins/blockdevice/linux.py
@@ -69,7 +69,6 @@ class LinuxBlockDevicePlugin(BaseBlockDevicePlugin):
                                  action=conf_action(config=context.ami),
                                  help='Parition number containing the root file system.')
 
-
     def __enter__(self):
         self._dev = self.allocate_dev()
         return self._dev.node
@@ -99,12 +98,12 @@ class LinuxBlockDevicePlugin(BaseBlockDevicePlugin):
         if block_config.use_minor_device_numbers:
             device_format = '/dev/{0}{1}{2}'
             self._allowed_devices = [device_format.format(self._device_prefix, major, minor)
-                                        for major in majors
-                                        for minor in xrange(1, 16)]
+                                     for major in majors
+                                     for minor in xrange(1, 16)]
         else:
             device_format = '/dev/{0}{1}'
             self._allowed_devices = [device_format.format(self._device_prefix, major)
-                                        for major in majors]
+                                     for major in majors]
 
     def allocate_dev(self):
         context = self._config.context

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,3 +81,6 @@ aminator.plugins.metrics =
 
 [bdist_rpm]
 requires = python-boto >= 2.7 python-bunch python-decorator python-logutils python-pyyaml python-requests python-stevedore python-simplejson
+
+[flake8]
+ignore = E501


### PR DESCRIPTION
This fixes #234 -- allows one to avoid use of minor devices (/dev/xvdg1 versus /dev/xvdg) for block device allocation as HVM instances in EC2 can only have EBS volumes attached to major devices.



cc @coryb @kvick 