### PR TITLE
better handling of multibyte unicode output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ aminator - Easily create application-specific custom AMIs
 
 Aminator creates a custom AMI from just:
 
-* A base ami ID 
+* A base ami ID
 * A link to a deb or rpm package that installs your application.
 
 This is useful for many AWS workflows, particularly ones that take advantage of auto-scaling groups.
@@ -11,7 +11,7 @@ This is useful for many AWS workflows, particularly ones that take advantage of 
 Requirements
 ------------
 
-* Python 2.6+ (Python 3.x support not yet available)
+* Python 2.7 (Python 3.x support not yet available)
 * Linux or UNIX cloud instance (EC2 currently supported)
 
 Installation

--- a/aminator/util/linux.py
+++ b/aminator/util/linux.py
@@ -106,8 +106,8 @@ def monitor_command(cmd, timeout=None):
 
     io_streams = [stdout, stderr]
 
-    std_out = ""
-    std_err = ""
+    std_out = u''
+    std_err = u''
     with stdout, stderr:
         while io_streams:
             reads, _, _ = select(io_streams, [], [])
@@ -119,10 +119,10 @@ def monitor_command(cmd, timeout=None):
                 else:
                     buf = buf.encode('utf-8')
                     if fd == stderr:
-                        log.debug("STDERR: {0}".format(buf))
+                        log.debug(u'STDERR: {0}'.format(buf))
                         std_err += buf
                     else:
-                        if buf[-1] == "\n":
+                        if buf[-1] == u'\n':
                             log.debug(buf[:-1])
                         else:
                             log.debug(buf)

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,4 +83,4 @@ aminator.plugins.metrics =
 requires = python-boto >= 2.7 python-bunch python-decorator python-logutils python-pyyaml python-requests python-stevedore python-simplejson
 
 [flake8]
-ignore = E501
+ignore = E501, E731


### PR DESCRIPTION
Wrap Popen.stdout and .stderr with io.open (which will open in text mode) and encode the buffer as utf-8 before doing anything with it

(cc @coryb )