### PR TITLE
Convert tuple to list to avoid concatenation type errors

### DIFF
--- a/aminator/plugins/provisioner/apt.py
+++ b/aminator/plugins/provisioner/apt.py
@@ -145,7 +145,7 @@ class AptProvisionerPlugin(BaseProvisionerPlugin):
 
     @staticmethod
     def apt_get_install(*options):
-        install_result = monitor_command(['apt-get', '-y', 'install'] + options)
+        install_result = monitor_command(['apt-get', '-y', 'install'] + list(options))
         if not install_result.success:
             log.debug('failure:{0.command} :{0.std_err}'.format(install_result.result))
         return install_result


### PR DESCRIPTION
When using the apt provisioner, I get the following error:

   File "/usr/local/aminator/local/lib/python2.7/site-packages/aminator/plugins/provisioner/apt.py", line 148, in apt_get_install
    install_result = monitor_command(['apt-get', '-y', 'install'] + options)
TypeError: can only concatenate list (not "tuple") to list

Casting the options tuple as a list allows concatenation.  Seems to run successfully since I made the change.