### PR TITLE
quiet down plugins.cloud.ec2.EC2CloudPlugin.delete_volume

### DIFF
--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -287,17 +287,12 @@ class EC2CloudPlugin(BaseCloudPlugin):
             return True
 
         log.debug('Deleting volume {0}'.format(self._volume.id))
-        self._volume.delete()
-        return self._volume_deleted()
-
-    def _volume_deleted(self):
-        try:
-            self._volume.update()
-        except EC2ResponseError, e:
-            if e.code == 'InvalidVolume.NotFound':
-                log.debug('Volume {0} successfully deleted'.format(self._volume.id))
-                return True
-            return False
+        result = self._volume.delete()
+        if not result:
+            log.debug('Volume {0} delete returned False, may require manual cleanup'.format(self._volume.id))
+        else:
+            log.debug('Volume {0} successfully deleted'.format(self._volume.id))
+        return result
 
     def is_stale_attachment(self, dev, prefix):
         log.debug('Checking for stale attachment. dev: {0}, prefix: {1}'.format(dev, prefix))


### PR DESCRIPTION
boto.ec2.Volume.delete() simply returns True/False upon success/failure, but spews to ERROR if boto.ec2.Volume.update() is called against a non-existent volume (which ends up dropping an XML error that may confuse end users). Simply rely on Volume.delete() returning True/False and log (to DEBUG for now) if a volume deletion returns False

cc @coryb -- this should get rid of 

```
2016-08-11 04:28:24 - 400 Bad Request
2016-08-11 04:28:24 - <?xml version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>InvalidVolume.NotFound</Code><Message>The volume 'vol-xxxxxxxxx' does not exist.</Message></Error></Errors><RequestID>xxxxxxxxxx</RequestID></Response>
```

from output in the internal UI