### PR TITLE
cache base ami lookup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ pyyaml
 requests
 stevedore
 simplejson
+dill
+


### PR DESCRIPTION
@bmoyles 
lets cache the base ami lookup since base changes infrequently and can be very slow to lookup

using dill due to recursive data structures within boto.ec2.image.Image objects.  json, yaml and pickle failed to serialize/deserialize correctly.

