### PR TITLE
Enable ENA support during AMI registration

### DIFF
--- a/aminator/__init__.py
+++ b/aminator/__init__.py
@@ -35,7 +35,7 @@ except ImportError:
             def emit(self, record):
                 pass
 
-__version__ = '2.1.85.dev'
+__version__ = '2.2.0.dev'
 __versioninfo__ = __version__.split('.')
 __all__ = ()
 

--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -335,6 +335,7 @@ class EC2CloudPlugin(BaseCloudPlugin):
             client = boto3.client('ec2', region_name=ami_metadata.get('region'))
             response = client.register_image(**request)
             log.debug('Registration response data [{}]'.format(response))
+
             ami_id = response['ImageId']
             if ami_id is None:
                 return False
@@ -347,7 +348,7 @@ class EC2CloudPlugin(BaseCloudPlugin):
             waiter.wait(**wait_request)
             # Now, using boto2, load the Image so downstream tagging operations work
             # using boto2 classes
-            log.debug('loading Image for [{}]'.format(ami_id))
+            log.debug('Image available!  Loading boto2.Image for [{}]'.format(ami_id))
             self._ami = self._connection.get_image(ami_id)
         except ClientError as e:
             if e['Error']['Code'] == 'InvalidAMIID.NotFound':

--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -332,7 +332,7 @@ class EC2CloudPlugin(BaseCloudPlugin):
           
         log.debug('Boto3 registration request data [{}]'.format(request))
 
-	try:
+	    try:
             client = boto3.client('ec2', region_name=ami_metadata.get('region'))
             response = client.register_image(**request)
         except ClientError as e:
@@ -343,29 +343,28 @@ class EC2CloudPlugin(BaseCloudPlugin):
 
         ami_id = response['ImageId']
 
-	if ami_id is None:
+	    if ami_id is None:
             return False
 
-	try:
-            # not 100% sure this is
+	    try:
             log.info('Waiting for [{}] to become available'.format(ami_id))
-	    waiter = client.get_waiter('image_available')
-	    wait_request = {}
+	        waiter = client.get_waiter('image_available')
+	        wait_request = {}
             wait_request['ImageIds'] = []
-	    wait_request['ImageIds'].append(ami_id)
+	        wait_request['ImageIds'].append(ami_id)
             waiter.wait(**wait_request)
 
-	    # Now, using boto2, load the Image so downstream tagging operations work
+	        # Now, using boto2, load the Image so downstream tagging operations work
             # using boto2 classes
             log.debug('loading Image for [{}]'.format(ami_id))
-	    self._ami = self._connection.get_image(ami_id)
+	        self._ami = self._connection.get_image(ami_id)
        	except ClientError as e:
             if e['Error']['Code'] == 'InvalidAMIID.NotFound':
                 log.debug('{0} was not found while waiting for it to become available'.format(ami_id))
             else:
                 raise e
 
-	self._config.context.ami.image = self._ami
+	    self._config.context.ami.image = self._ami
 
         return True
 

--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -33,8 +33,10 @@ from boto.ec2.instance import Instance
 from boto.ec2.volume import Volume
 from boto.exception import EC2ResponseError
 from boto.utils import get_instance_metadata
+from botocore.exceptions import ClientError
 from decorator import decorator
 from os import environ
+import boto3
 import os.path
 import dill
 
@@ -306,36 +308,80 @@ class EC2CloudPlugin(BaseCloudPlugin):
 
     @registration_retry(tries=3, delay=1, backoff=1)
     def _register_image(self, **ami_metadata):
-        context = self._config.context
-        ami = Image(connection=self._connection)
-        ami.id = self._connection.register_image(**ami_metadata)
-        if ami.id is None:
+        """Register the AMI using boto3/botocore components which supports ENA
+           This is the only use of boto3 in aminator currently""" 
+
+        # construct AMI registration payload boto3 style
+        request = {} 
+        request['Name'] = ami_metadata.pop('name')
+        request['Description'] = ami_metadata.pop('description')
+        request['Architecture'] = ami_metadata.pop('architecture')
+        request['BlockDeviceMappings'] = ami_metadata.pop('block_device_map')
+        request['VirtualizationType'] = ami_metadata.pop('virtualization_type')
+        request['RootDeviceName'] = ami_metadata.pop('root_device_name')
+
+        if (ami_metadata.get('virtualization_type') == 'pv'):
+            request['KernelId'] = ami_metadata.pop('kernel_id')
+            request['RamdiskId'] = ami_metadata.pop('ramdisk_id')
+
+        if (ami_metadata.get('sriov_net_support')):
+            request['SriovNetSupport'] = ami_metadata.pop('sriov_net_support')
+
+        if (ami_metadata.get('ena_networking')):
+            request['EnaSupport'] = ami_metadata.pop('ena_networking')
+          
+        log.debug('Boto3 registration request data [{}]'.format(request))
+
+	try:
+            client = boto3.client('ec2', region_name=ami_metadata.get('region'))
+            response = client.register_image(**request)
+        except ClientError as e:
+            log.error('Error during register_image: {}'.format(e))
             return False
-        else:
-            while True:
-                # spin until Amazon recognizes the AMI ID it told us about
-                try:
-                    sleep(2)
-                    ami.update()
-                    break
-                except EC2ResponseError, e:
-                    if e.error_code == 'InvalidAMIID.NotFound':
-                        log.debug('{0} not found, retrying'.format(ami.id))
-                    else:
-                        raise e
-            log.info('AMI registered: {0} {1}'.format(ami.id, ami.name))
-            context.ami.image = self._ami = ami
-            return True
+
+        log.debug('Registration response data [{}]'.format(response))
+
+        ami_id = response['ImageId']
+
+	if ami_id is None:
+            return False
+
+	try:
+            # not 100% sure this is
+            log.info('Waiting for [{}] to become available'.format(ami_id))
+	    waiter = client.get_waiter('image_available')
+	    wait_request = {}
+            wait_request['ImageIds'] = []
+	    wait_request['ImageIds'].append(ami_id)
+            waiter.wait(**wait_request)
+
+	    # Now, using boto2, load the Image so downstream tagging operations work
+            # using boto2 classes
+            log.debug('loading Image for [{}]'.format(ami_id))
+	    self._ami = self._connection.get_image(ami_id)
+       	except ClientError as e:
+            if e['Error']['Code'] == 'InvalidAMIID.NotFound':
+                log.debug('{0} was not found while waiting for it to become available'.format(ami_id))
+            else:
+                raise e
+
+	self._config.context.ami.image = self._ami
+
+        return True
 
     def register_image(self, *args, **kwargs):
         context = self._config.context
         vm_type = context.ami.get("vm_type", "paravirtual")
+        cloud_config = self._config.plugins[self.full_name]
+        self._instance_metadata = get_instance_metadata()
+        instance_region = self._instance_metadata['placement']['availability-zone'][:-1]
+        region = kwargs.pop('region', context.get('region', cloud_config.get('region', instance_region)))
         if 'manifest' in kwargs:
             ami_metadata = {
                 'name': context.ami.name,
                 'description': context.ami.description,
                 'image_location': kwargs['manifest'],
-                'virtualization_type': vm_type
+                'virtualization_type': vm_type,
             }
         else:
             # args will be [block_device_map, root_block_device]
@@ -345,11 +391,13 @@ class EC2CloudPlugin(BaseCloudPlugin):
                 'name': context.ami.name,
                 'description': context.ami.description,
                 'block_device_map': bdm,
+                'block_device_map_list': block_device_map,
                 'root_device_name': root_block_device,
                 'kernel_id': context.base_ami.kernel_id,
                 'ramdisk_id': context.base_ami.ramdisk_id,
                 'architecture': context.base_ami.architecture,
-                'virtualization_type': vm_type
+                'virtualization_type': vm_type,
+                'region': region
             }
             if vm_type == "hvm":
                 del ami_metadata['kernel_id']
@@ -358,16 +406,37 @@ class EC2CloudPlugin(BaseCloudPlugin):
         if vm_type == 'hvm':
             if context.ami.get("enhanced_networking", False):
                 ami_metadata['sriov_net_support'] = 'simple'
+            if context.ami.get("ena_networking", False):
+                ami_metadata['ena_networking'] = True
 
         if not self._register_image(**ami_metadata):
             return False
+
         return True
 
-    def _make_block_device_map(self, block_device_map, root_block_device):
-        bdm = BlockDeviceMapping(connection=self._connection)
-        bdm[root_block_device] = BlockDeviceType(snapshot_id=self._snapshot.id, delete_on_termination=True)
+    def _make_block_device_map(self, block_device_map, root_block_device, delete_on_termination=True):
+	""" construct boto3 style BlockDeviceMapping """
+
+        bdm = []
+
+        # root device
+        root_mapping = {}
+        root_mapping['DeviceName'] = root_block_device
+        root_mapping['Ebs'] = {}
+        root_mapping['Ebs']['SnapshotId'] = self._snapshot.id
+        root_mapping['Ebs']['VolumeSize'] = self._volume.size
+        root_mapping['Ebs']['VolumeType'] = self._volume.type
+        root_mapping['Ebs']['DeleteOnTermination'] = delete_on_termination
+        bdm.append(root_mapping)
+
+        # ephemerals
         for (os_dev, ec2_dev) in block_device_map:
-            bdm[os_dev] = BlockDeviceType(ephemeral_name=ec2_dev)
+            mapping = {}
+            mapping['VirtualName'] = ec2_dev
+            mapping['DeviceName'] = os_dev
+	    bdm.append(mapping)
+
+        log.debug('Created BlockDeviceMapping [{}]'.format(bdm))
         return bdm
 
     @retry(FinalizerException, tries=3, delay=1, backoff=2, logger=log)

--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -329,8 +329,9 @@ class EC2CloudPlugin(BaseCloudPlugin):
             if request[key] is None:
                 raise FinalizerException('{} cannot be None'.format(key))
 
-        # this will be None for pv, set to 'simple' for hvm
-        request['SriovNetSupport'] = ami_metadata.get('sriov_net_support', None)
+        # can only be set to 'simple' for hvm.  don't include otherwise
+        if ami_metadata.get('sriov_net_support') is not None:
+            request['SriovNetSupport'] = ami_metadata.get('sriov_net_support')
 
         log.debug('Boto3 registration request data [{}]'.format(request))
 
@@ -427,8 +428,7 @@ class EC2CloudPlugin(BaseCloudPlugin):
             mapping = {}
             mapping['VirtualName'] = ec2_dev
             mapping['DeviceName'] = os_dev
-
-        bdm.append(mapping)
+            bdm.append(mapping)
 
         log.debug('Created BlockDeviceMapping [{}]'.format(bdm))
         return bdm

--- a/aminator/plugins/finalizer/tagging_base.py
+++ b/aminator/plugins/finalizer/tagging_base.py
@@ -47,6 +47,7 @@ class TaggingBaseFinalizerPlugin(BaseFinalizerPlugin):
         tagging.add_argument('-c', '--creator', dest='creator', action=conf_action(context.ami), help=creator_help)
         tagging.add_argument('--vm-type', dest='vm_type', choices=["paravirtual", "hvm"], action=conf_action(context.ami), help='virtualization type to register image as')
         tagging.add_argument('--enhanced-networking', dest='enhanced_networking', action=conf_action(context.ami, action='store_true'), help='enable enhanced networking (SR-IOV)')
+        tagging.add_argument('--ena-networking', dest='ena_networking', action=conf_action(context.ami, action='store_true'), help='enable elastic network adapter support (ENA)')
         return tagging
 
     def _set_metadata(self):
@@ -123,10 +124,16 @@ class TaggingBaseFinalizerPlugin(BaseFinalizerPlugin):
             environ["AMINATOR_VM_TYPE"] = context.ami.vm_type
         if context.ami.get("enhanced_networking", None):
             environ["AMINATOR_ENHANCED_NETWORKING"] = str(int(context.ami.enhanced_networking))
+        if context.ami.get("ena_networking", None):
+            environ["AMINATOR_ENA_NETWORKING"] = str(int(context.ami.ena_networking))
 
         if context.ami.get("enhanced_networking", False):
             if context.ami.get("vm_type", "paravirtual") != "hvm":
                 raise ValueError("--enhanced-networking requires --vm-type hvm")
+
+        if context.ami.get("ena_networking", False):
+            if context.ami.get("vm_type", "paravirtual") != "hvm":
+                raise ValueError("--ena-networking requires --vm-type hvm")
 
         return self
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+boto>=2.7
 boto3
 bunch
 decorator

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto>=2.7
+boto3
 bunch
 decorator
 logutils

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto>=2.7
-boto3
+boto3>=1.4.4
 bunch
 decorator
 logutils


### PR DESCRIPTION
Per issue #249, refactor _register_image to use boto3 which supports setting the EnaSupport flag during AMI registration, when specified during the aminate call.