### PR TITLE
Fix instance-store registration using boto3 and add architecture config and cli option

### DIFF
--- a/aminator/__init__.py
+++ b/aminator/__init__.py
@@ -35,7 +35,7 @@ except ImportError:
             def emit(self, record):
                 pass
 
-__version__ = '2.2.0.dev'
+__version__ = '2.2.1.dev'
 __versioninfo__ = __version__.split('.')
 __all__ = ()
 

--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -317,6 +317,11 @@ class EC2CloudPlugin(BaseCloudPlugin):
         request['EnaSupport'] = ami_metadata.get('ena_networking', False)
         request['VirtualizationType'] = ami_metadata.get('virtualization_type', None)
 
+        if ami_metadata.get('block_device_map') is not None:
+            request['BlockDeviceMappings'] = ami_metadata.get('block_device_map')
+        if ami_metadata.get('root_device_name') is not None:
+            request['RootDeviceName'] = ami_metadata.get('root_device_name')
+
         if (ami_metadata.get('virtualization_type') == 'paravirtual'):
             # KernelId required
             request['KernelId'] = ami_metadata.get('kernel_id', None)
@@ -327,10 +332,6 @@ class EC2CloudPlugin(BaseCloudPlugin):
         for key, value in request.items():
             if request[key] is None:
                 raise FinalizerException('{} cannot be None'.format(key))
-
-        # these can be None for instance store (S3) AMIs
-        request['BlockDeviceMappings'] = ami_metadata.get('block_device_map', None)
-        request['RootDeviceName'] = ami_metadata.get('root_device_name', None)
 
         # can only be set to 'simple' for hvm.  don't include otherwise
         if ami_metadata.get('sriov_net_support') is not None:

--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -314,19 +314,21 @@ class EC2CloudPlugin(BaseCloudPlugin):
         request['Name'] = ami_metadata.get('name', None)
         request['Description'] = ami_metadata.get('description', None)
         request['Architecture'] = ami_metadata.get('architecture', None)
-        request['BlockDeviceMappings'] = ami_metadata.get('block_device_map', None)
-        request['VirtualizationType'] = ami_metadata.get('virtualization_type', None)
-        request['RootDeviceName'] = ami_metadata.get('root_device_name', None)
         request['EnaSupport'] = ami_metadata.get('ena_networking', False)
+        request['VirtualizationType'] = ami_metadata.get('virtualization_type', None)
 
-        if (ami_metadata.get('virtualization_type') == 'pv'):
+        if (ami_metadata.get('virtualization_type') == 'paravirtual'):
             request['KernelId'] = ami_metadata.get('kernel_id', None)
             request['RamdiskId'] = ami_metadata.get('ramdisk_id', None)
 
-        # assert we have all the key params we need, nothing should be None
+        # assert we have all the key params. Nothing to _here_ should be None
         for key, value in request.items():
             if request[key] is None:
                 raise FinalizerException('{} cannot be None'.format(key))
+
+        # these can be None for S3 backed AMIs
+        request['BlockDeviceMappings'] = ami_metadata.get('block_device_map', None)
+        request['RootDeviceName'] = ami_metadata.get('root_device_name', None)
 
         # can only be set to 'simple' for hvm.  don't include otherwise
         if ami_metadata.get('sriov_net_support') is not None:

--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -382,6 +382,7 @@ class EC2CloudPlugin(BaseCloudPlugin):
                 'description': context.ami.description,
                 'image_location': kwargs['manifest'],
                 'virtualization_type': vm_type,
+                'architecture': context.base_ami.architecture
             }
         else:
             # args will be [block_device_map, root_block_device]

--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -313,7 +313,7 @@ class EC2CloudPlugin(BaseCloudPlugin):
         request = {}
         request['Name'] = ami_metadata.get('name', None)
         request['Description'] = ami_metadata.get('description', None)
-        request['Architecture'] = ami_metadata.get('architecture', None)
+        request['Architecture'] = ami_metadata.get('architecture', 'x86_64')
         request['EnaSupport'] = ami_metadata.get('ena_networking', False)
         request['VirtualizationType'] = ami_metadata.get('virtualization_type', None)
 

--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -321,9 +321,11 @@ class EC2CloudPlugin(BaseCloudPlugin):
             request['BlockDeviceMappings'] = ami_metadata.get('block_device_map')
         if ami_metadata.get('root_device_name') is not None:
             request['RootDeviceName'] = ami_metadata.get('root_device_name')
+        if ami_metadata.get('image_location') is not None:
+            request['ImageLocation'] = ami_metadata.get('image_location')
 
         if (ami_metadata.get('virtualization_type') == 'paravirtual'):
-            # KernelId required
+            # KernelId required, 
             request['KernelId'] = ami_metadata.get('kernel_id', None)
             if ami_metadata.get('ramdisk_id') is not None:
                 request['RamdiskId'] = ami_metadata.get('ramdisk_id', None)

--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -318,15 +318,17 @@ class EC2CloudPlugin(BaseCloudPlugin):
         request['VirtualizationType'] = ami_metadata.get('virtualization_type', None)
 
         if (ami_metadata.get('virtualization_type') == 'paravirtual'):
+            # KernelId required
             request['KernelId'] = ami_metadata.get('kernel_id', None)
-            request['RamdiskId'] = ami_metadata.get('ramdisk_id', None)
+            if ami_metadata.get('ramdisk_id') is not None:
+                request['RamdiskId'] = ami_metadata.get('ramdisk_id', None)
 
         # assert we have all the key params. Nothing to _here_ should be None
         for key, value in request.items():
             if request[key] is None:
                 raise FinalizerException('{} cannot be None'.format(key))
 
-        # these can be None for S3 backed AMIs
+        # these can be None for instance store (S3) AMIs
         request['BlockDeviceMappings'] = ami_metadata.get('block_device_map', None)
         request['RootDeviceName'] = ami_metadata.get('root_device_name', None)
 

--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -313,19 +313,26 @@ class EC2CloudPlugin(BaseCloudPlugin):
         request = {}
         request['Name'] = ami_metadata.get('name', None)
         request['Description'] = ami_metadata.get('description', None)
-        request['Architecture'] = ami_metadata.get('architecture', 'x86_64')
+        request['Architecture'] = ami_metadata.get('architecture', None)
         request['EnaSupport'] = ami_metadata.get('ena_networking', False)
         request['VirtualizationType'] = ami_metadata.get('virtualization_type', None)
 
+        # when instance store, don't provide botocore expects a string value
         if ami_metadata.get('block_device_map') is not None:
             request['BlockDeviceMappings'] = ami_metadata.get('block_device_map')
         if ami_metadata.get('root_device_name') is not None:
             request['RootDeviceName'] = ami_metadata.get('root_device_name')
+
+        # only present for instance store
         if ami_metadata.get('image_location') is not None:
             request['ImageLocation'] = ami_metadata.get('image_location')
 
+        # can only be set to 'simple' for hvm.  don't include otherwise
+        if ami_metadata.get('sriov_net_support') is not None:
+            request['SriovNetSupport'] = ami_metadata.get('sriov_net_support')
+
         if (ami_metadata.get('virtualization_type') == 'paravirtual'):
-            # KernelId required, 
+            # KernelId required
             request['KernelId'] = ami_metadata.get('kernel_id', None)
             if ami_metadata.get('ramdisk_id') is not None:
                 request['RamdiskId'] = ami_metadata.get('ramdisk_id', None)
@@ -334,10 +341,6 @@ class EC2CloudPlugin(BaseCloudPlugin):
         for key, value in request.items():
             if request[key] is None:
                 raise FinalizerException('{} cannot be None'.format(key))
-
-        # can only be set to 'simple' for hvm.  don't include otherwise
-        if ami_metadata.get('sriov_net_support') is not None:
-            request['SriovNetSupport'] = ami_metadata.get('sriov_net_support')
 
         log.debug('Boto3 registration request data [{}]'.format(request))
 
@@ -377,37 +380,32 @@ class EC2CloudPlugin(BaseCloudPlugin):
     def register_image(self, *args, **kwargs):
         context = self._config.context
         vm_type = context.ami.get("vm_type", "paravirtual")
+        architecture = context.ami.get("architecture", "x86_64")
         cloud_config = self._config.plugins[self.full_name]
         self._instance_metadata = get_instance_metadata()
         instance_region = self._instance_metadata['placement']['availability-zone'][:-1]
         region = kwargs.pop('region', context.get('region', cloud_config.get('region', instance_region)))
+
+        ami_metadata = {
+            'name': context.ami.name,
+            'description': context.ami.description,
+            'virtualization_type': vm_type,
+            'architecture': architecture,
+            'kernel_id': context.base_ami.kernel_id,
+            'ramdisk_id': context.base_ami.ramdisk_id,
+            'region': region
+        }
+
         if 'manifest' in kwargs:
-            ami_metadata = {
-                'name': context.ami.name,
-                'description': context.ami.description,
-                'image_location': kwargs['manifest'],
-                'virtualization_type': vm_type,
-                'architecture': context.base_ami.architecture,
-                'kernel_id': context.base_ami.kernel_id,
-                'ramdisk_id': context.base_ami.ramdisk_id,
-                'region': region
-            }
+            # it's an instance store AMI and needs bucket location
+            ami_metadata['image_location'] = kwargs['manifest']
         else:
             # args will be [block_device_map, root_block_device]
             block_device_map, root_block_device = args[:2]
             bdm = self._make_block_device_map(block_device_map, root_block_device)
-            ami_metadata = {
-                'name': context.ami.name,
-                'description': context.ami.description,
-                'block_device_map': bdm,
-                'block_device_map_list': block_device_map,
-                'root_device_name': root_block_device,
-                'kernel_id': context.base_ami.kernel_id,
-                'ramdisk_id': context.base_ami.ramdisk_id,
-                'architecture': context.base_ami.architecture,
-                'virtualization_type': vm_type,
-                'region': region
-            }
+            ami_metadata['block_device_map'] = bdm
+            ami_metadata['block_device_map_list'] = block_device_map
+            ami_metadata['root_device_name'] = root_block_device
 
         if vm_type == 'hvm':
             del ami_metadata['kernel_id']

--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -388,6 +388,8 @@ class EC2CloudPlugin(BaseCloudPlugin):
                 'image_location': kwargs['manifest'],
                 'virtualization_type': vm_type,
                 'architecture': context.base_ami.architecture,
+                'kernel_id': context.base_ami.kernel_id,
+                'ramdisk_id': context.base_ami.ramdisk_id,
                 'region': region
             }
         else:
@@ -406,11 +408,10 @@ class EC2CloudPlugin(BaseCloudPlugin):
                 'virtualization_type': vm_type,
                 'region': region
             }
-            if vm_type == "hvm":
-                del ami_metadata['kernel_id']
-                del ami_metadata['ramdisk_id']
 
         if vm_type == 'hvm':
+            del ami_metadata['kernel_id']
+            del ami_metadata['ramdisk_id']
             if context.ami.get("enhanced_networking", False):
                 ami_metadata['sriov_net_support'] = 'simple'
             ami_metadata['ena_networking'] = context.ami.get('ena_networking', False)

--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -384,7 +384,8 @@ class EC2CloudPlugin(BaseCloudPlugin):
                 'description': context.ami.description,
                 'image_location': kwargs['manifest'],
                 'virtualization_type': vm_type,
-                'architecture': context.base_ami.architecture
+                'architecture': context.base_ami.architecture,
+                'region': region
             }
         else:
             # args will be [block_device_map, root_block_device]

--- a/aminator/plugins/finalizer/default_conf/aminator.plugins.finalizer.tagging_ebs.yml
+++ b/aminator/plugins/finalizer/default_conf/aminator.plugins.finalizer.tagging_ebs.yml
@@ -12,3 +12,4 @@ default_block_device_map:
   - [/dev/sdc, ephemeral1]
   - [/dev/sdd, ephemeral2]
   - [/dev/sde, ephemeral3]
+default_architecture: x86_64

--- a/aminator/plugins/finalizer/default_conf/aminator.plugins.finalizer.tagging_s3.yml
+++ b/aminator/plugins/finalizer/default_conf/aminator.plugins.finalizer.tagging_s3.yml
@@ -18,3 +18,4 @@ default_block_device_map:
   - [/dev/sdc, ephemeral1]
   - [/dev/sdd, ephemeral2]
   - [/dev/sde, ephemeral3]
+default_architecture: x86_64

--- a/aminator/plugins/finalizer/tagging_base.py
+++ b/aminator/plugins/finalizer/tagging_base.py
@@ -48,6 +48,7 @@ class TaggingBaseFinalizerPlugin(BaseFinalizerPlugin):
         tagging.add_argument('--vm-type', dest='vm_type', choices=["paravirtual", "hvm"], action=conf_action(context.ami), help='virtualization type to register image as')
         tagging.add_argument('--enhanced-networking', dest='enhanced_networking', action=conf_action(context.ami, action='store_true'), help='enable enhanced networking (SR-IOV)')
         tagging.add_argument('--ena-networking', dest='ena_networking', action=conf_action(context.ami, action='store_true'), help='enable elastic network adapter support (ENA)')
+        tagging.add_argument('--arch', dest='architecture', choices=["i386", "x86_64"], action=conf_action(context.ami), help='architecture to register image as')
         return tagging
 
     def _set_metadata(self):


### PR DESCRIPTION
So this _should_ wrap up #252 and #249 with fixes to some problems when doing instance-store registrations and providing correct parameters.  Surprisingly `architecture`, wasn't getting propagated correctly for instance store bakes (I kept thinking it should have been in `context.base_ami.architecture`), so decided to make it a default configuration and overridable via the finalizers per @bmoyles feedback.

The Caveat Emptor here is that this will now happily allow you to bake on `x86_64` and register it as `i386`