### PR TITLE
allow specification of EBS volume types in ec2 cloud plugin

### DIFF
--- a/aminator/plugins/cloud/default_conf/aminator.plugins.cloud.ec2.yml
+++ b/aminator/plugins/cloud/default_conf/aminator.plugins.cloud.ec2.yml
@@ -9,4 +9,6 @@ ephemeral_devices:
   - /dev/sde
 is_secure: true
 root_device: /dev/sda1
+provisioner_ebs_type: standard
+register_ebs_type: standard
 #region:


### PR DESCRIPTION
this allows for control of the provisioner volume as well as the final root volume EBS registration type, both from configuration and explicit override on the command line.