### PR TITLE
add default config stuff.  this fixes the AttributeErrors

### DIFF
--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -184,7 +184,7 @@ class EC2CloudPlugin(BaseCloudPlugin):
         self._volume = Volume(connection=self._connection)
 
         rootdev = context.base_ami.block_device_mapping[context.base_ami.root_device_name]
-        volume_type = context.cloud.provisioner_ebs_type
+        volume_type = context.cloud.get('provisioner_ebs_type', cloud_config.get('provisioner_ebs_type', 'standard'))
         self._volume.id = self._connection.create_volume(
             size=rootdev.size, zone=self._instance.placement,
             volume_type=volume_type, snapshot=rootdev.snapshot_id).id
@@ -453,8 +453,10 @@ class EC2CloudPlugin(BaseCloudPlugin):
         """ construct boto3 style BlockDeviceMapping """
 
         context = self._config.context
+        cloud_config = self._config.plugins[self.full_name]
 
         bdm = []
+        volume_type = context.cloud.get('register_ebs_type', cloud_config.get('register_ebs_type', 'standard'))
 
         # root device
         root_mapping = {}


### PR DESCRIPTION
During testing, received AttributeErrors during `allocate_base_volume`  Added config defaults.

`
  File "../python/local/lib/python2.7/site-packages/aminator/plugins/cloud/ec2.py", line 187, in allocate_base_volume
    volume_type = context.cloud.provisioner_ebs_type
  File ".../python/local/lib/python2.7/site-packages/bunch/__init__.py", line 121, in __getattr__
    raise AttributeError(k)
`