### PR TITLE
Bmoyles allow root volume size

### DIFF
--- a/aminator/plugins/base.py
+++ b/aminator/plugins/base.py
@@ -65,6 +65,20 @@ class BasePlugin(object):
     def full_name(self):
         return '{0}.{1}'.format(self.entry_point, self.name)
 
+    @property
+    def full_config(self):
+        return self._config
+
+    @property
+    def plugin_config(self):
+        config = self.full_config.get('plugins', {})
+        plugin_config = config.get(self.full_name, {})
+        return plugin_config
+
+    @property
+    def context(self):
+        return self.full_config.get('context', {})
+
     def configure(self, config, parser):
         """ Configure the plugin and contribute to command line args """
         log.debug("Configuring plugin {0} for entry point {1}".format(self.name, self.entry_point))
@@ -80,7 +94,7 @@ class BasePlugin(object):
     def load_plugin_config(self):
         entry_point = self.entry_point
         name = self.name
-        key = '.'.join((entry_point, name))
+        key = self.full_name
 
         if self._config.plugins.config_root.startswith('~'):
             plugin_conf_dir = os.path.expanduser(self._config.plugins.config_root)

--- a/aminator/plugins/cloud/default_conf/aminator.plugins.cloud.ec2.yml
+++ b/aminator/plugins/cloud/default_conf/aminator.plugins.cloud.ec2.yml
@@ -11,4 +11,5 @@ is_secure: true
 root_device: /dev/sda1
 provisioner_ebs_type: standard
 register_ebs_type: standard
+root_volume_size: 10
 #region:

--- a/aminator/plugins/finalizer/default_conf/aminator.plugins.finalizer.tagging_s3.yml
+++ b/aminator/plugins/finalizer/default_conf/aminator.plugins.finalizer.tagging_s3.yml
@@ -19,3 +19,4 @@ default_block_device_map:
   - [/dev/sdd, ephemeral2]
   - [/dev/sde, ephemeral3]
 default_architecture: x86_64
+max_root_volume_size: 10

--- a/aminator/plugins/volume/default_conf/aminator.plugins.volume.linux.yml
+++ b/aminator/plugins/volume/default_conf/aminator.plugins.volume.linux.yml
@@ -1,1 +1,2 @@
 enabled: true
+resize_volume: true

--- a/aminator/util/linux.py
+++ b/aminator/util/linux.py
@@ -147,6 +147,8 @@ def mounted(path):
 def fsck(dev):
     return monitor_command(['fsck', '-y', dev])
 
+def resize2fs(dev):
+    return monitor_command(['resize2fs', dev])
 
 def mount(mountspec):
     if not any((mountspec.dev, mountspec.mountpoint)):


### PR DESCRIPTION
Allows for specification of a root volume size as well as optional resize2fs which should (once the API is wired up) allow for specification of root volume sizes that exceed that of the base.