### PR TITLE
adjust default root volume size behavior

### DIFF
--- a/aminator/plugins/cloud/default_conf/aminator.plugins.cloud.ec2.yml
+++ b/aminator/plugins/cloud/default_conf/aminator.plugins.cloud.ec2.yml
@@ -11,5 +11,5 @@ is_secure: true
 root_device: /dev/sda1
 provisioner_ebs_type: standard
 register_ebs_type: standard
-root_volume_size: 10
+root_volume_size:
 #region:

--- a/aminator/plugins/cloud/ec2.py
+++ b/aminator/plugins/cloud/ec2.py
@@ -143,7 +143,7 @@ class EC2CloudPlugin(BaseCloudPlugin):
         cloud.add_argument(
             '--root-volume-size', dest='root_volume_size',
             action=conf_action(config=context.ami),
-            help='Root volume size (in GB)')
+            help='Root volume size (in GB). The default is to inherit from the base AMI.')
 
     def configure(self, config, parser):
         super(EC2CloudPlugin, self).configure(config, parser)
@@ -191,7 +191,9 @@ class EC2CloudPlugin(BaseCloudPlugin):
         volume_type = context.cloud.get('provisioner_ebs_type', cloud_config.get('provisioner_ebs_type', 'standard'))
         volume_size = context.ami.get('root_volume_size', None)
         if volume_size is None:
-            volume_size = cloud_config.get('root_volume_size', rootdev.size)
+            volume_size = cloud_config.get('root_volume_size', None)
+            if volume_size is None:
+                volume_size = rootdev.size
         volume_size = int(volume_size)
         if volume_size < 1:
             raise VolumeException('root_volume_size must be a positive integer, received {}'.format(volume_size))


### PR DESCRIPTION
default should be to not specify a fixed root volume size (but allow for that configuration), and when that volume size is not provided, inherit the size from the base AMI