### PR TITLE
an e2fsck return code of 1 should not be a failure

### DIFF
--- a/aminator/util/linux.py
+++ b/aminator/util/linux.py
@@ -145,7 +145,13 @@ def mounted(path):
 
 
 def fsck(dev):
-    return monitor_command(['fsck', '-y', '-f', dev])
+    cmd = monitor_command(['fsck', '-y', '-f', dev])
+    # e2fsck will exit 1 if it finds and corrects filesystem problems.
+    # consider that a success but fail all other exits as they should be legitimate
+    # problems that prevent a bake.
+    if not cmd.success and cmd.result.status_code == 1:
+        cmd = CommandResult(True, cmd.result)
+    return cmd
 
 
 def resize2fs(dev):


### PR DESCRIPTION
From `e2fsck(8)`

```
EXIT CODE
       The exit code returned by e2fsck is the sum of the following conditions:
            0    - No errors
            1    - File system errors corrected
            2    - File system errors corrected, system should
                   be rebooted
            4    - File system errors left uncorrected
            8    - Operational error
            16   - Usage or syntax error
            32   - E2fsck canceled by user request
            128  - Shared library error
```

I could be convinced to allow 2 as well, but given our patterns, suspect that's an unlikely result