### PR TITLE
partition-aware resize support

### DIFF
--- a/aminator/util/linux.py
+++ b/aminator/util/linux.py
@@ -158,6 +158,15 @@ def resize2fs(dev):
     return monitor_command(['resize2fs', dev])
 
 
+def growpart(dev, part):
+    cmd = monitor_command(['growpart', dev, part])
+    # growpart exits 1 when there is no free space to grow into, exits 2
+    # when a legitimate error is thrown
+    if not cmd.success and cmd.result.status_code == 1:
+        cmd = CommandResult(True, cmd.result)
+    return cmd
+
+
 def mount(mountspec):
     if not any((mountspec.dev, mountspec.mountpoint)):
         log.error('Must provide dev or mountpoint')


### PR DESCRIPTION
when root volume size support was added, partitioned volumes were not considered. this adds a growpart function for calling growpart against the partition prior to a resize2fs and ensures that fsck, resize2fs, and friends are all called against the partition, not the full block device