### PR TITLE
do some juggling to wrap the unmount call in a retry

### DIFF
--- a/aminator/exceptions.py
+++ b/aminator/exceptions.py
@@ -50,3 +50,7 @@ class ProvisionException(AminateException):
 
 class FinalizerException(AminateException):
     """ Errors during finalizing """
+
+
+class CommandException(AminateException):
+    """ Errors from external commands """


### PR DESCRIPTION
Inside umount, inspect the result and raise a new CommandException to trigger a retry. If we exhaust retries, the CommandException is still raised, so catch that in the caller and handle appropriately.
Could probably do without the else: clauses in the try/except as a run w/o an exception should return a result where result.success == True, but kept it in as a sanity check/safeguard.