### PR TITLE
recursive unmount support + better mount/unmount handling

### DIFF
--- a/aminator/environment.py
+++ b/aminator/environment.py
@@ -57,8 +57,8 @@ class Environment(object):
         with self.metrics:  # pylint: disable=no-member
             with self.cloud as cloud:  # pylint: disable=no-member
                 with self.finalizer(cloud) as finalizer:  # pylint: disable=no-member
-                    with self.volume(self.cloud, self.blockdevice) as volume:  # pylint: disable=no-member
-                        with self.distro(volume) as distro:  # pylint: disable=no-member
+                    with self.volume(self.cloud, self.blockdevice):  # pylint: disable=no-member
+                        with self.distro as distro:  # pylint: disable=no-member
                             success = self.provisioner(distro).provision()  # pylint: disable=no-member
                             if not success:
                                 log.critical('Provisioning failed!')

--- a/aminator/exceptions.py
+++ b/aminator/exceptions.py
@@ -50,7 +50,3 @@ class ProvisionException(AminateException):
 
 class FinalizerException(AminateException):
     """ Errors during finalizing """
-
-
-class CommandException(AminateException):
-    """ Errors from external commands """

--- a/aminator/plugins/distro/base.py
+++ b/aminator/plugins/distro/base.py
@@ -51,7 +51,3 @@ class BaseDistroPlugin(BasePlugin):
             log.debug('Exception encountered in distro plugin context manager',
                       exc_info=(exc_type, exc_value, trace))
         return False
-
-    def __call__(self, mountpoint):
-        self._mountpoint = mountpoint
-        return self

--- a/aminator/plugins/distro/debian.py
+++ b/aminator/plugins/distro/debian.py
@@ -24,7 +24,7 @@ aminator.plugins.distro.debian
 basic debian distro
 """
 import logging
-import os
+import os.path
 
 from aminator.plugins.distro.linux import BaseLinuxDistroPlugin
 
@@ -48,9 +48,10 @@ class DebianDistroPlugin(BaseLinuxDistroPlugin):
         if not super(DebianDistroPlugin, self)._deactivate_provisioning_service_block():
             return False
 
-        config = self._config.plugins[self.full_name]
-        path = self._mountpoint + config.get('policy_file_path', '')
-        filename = path + "/" + config.get('policy_file')
+        config = self.plugin_config
+        path = os.path.join(
+            self.root_mountspec.mountpoint, config.get('policy_file_path', ''))
+        filename = os.path.join(path, config.get('policy_file'))
 
         if not os.path.isdir(path):
             log.debug("creating %s", path)
@@ -73,10 +74,12 @@ class DebianDistroPlugin(BaseLinuxDistroPlugin):
         if not super(DebianDistroPlugin, self)._activate_provisioning_service_block():
             return False
 
-        config = self._config.plugins[self.full_name]
+        config = self.plugin_config
 
-        policy_file = self._mountpoint + "/" + config.get('policy_file_path', '') + "/" + \
-            config.get('policy_file', '')
+        policy_file = os.path.join(
+            self.root_mountspec.mountpoint,
+            config.get('policy_file_path', ''),
+            config.get('policy_file', ''))
 
         if os.path.isfile(policy_file):
             log.debug("removing %s", policy_file)

--- a/aminator/plugins/distro/default_conf/aminator.plugins.distro.debian.yml
+++ b/aminator/plugins/distro/default_conf/aminator.plugins.distro.debian.yml
@@ -8,12 +8,13 @@ short_circuit_files:
 chroot_mounts:
     - [proc, proc, /proc, null]
     - [sysfs, sysfs, /sys, null]
-    # Note: on Ubuntu Xenial (16.04) you need --make-private option on the
-    # /dev bind mount which can be accomplished with:
-    # - [/dev, bind, /dev, "rw --make-private"]
+    # Note: on Ubuntu 16.04 and later, bind mounts need the 'private' option
+    # - [/dev, bind, /dev, 'private']
     - [/dev, bind, /dev, null]
     - [devpts, devpts, /dev/pts, null]
     - [binfmt_misc, binfmt_misc, /proc/sys/fs/binfmt_misc, null]
+
+recursive_unmount: false
 
 provision_configs: true
 provision_config_files:

--- a/aminator/plugins/distro/default_conf/aminator.plugins.distro.redhat.yml
+++ b/aminator/plugins/distro/default_conf/aminator.plugins.distro.redhat.yml
@@ -13,6 +13,8 @@ chroot_mounts:
     - [devpts, devpts, /dev/pts, null]
     - [binfmt_misc, binfmt_misc, /proc/sys/fs/binfmt_misc, null]
 
+recursive_unmount: false
+
 provision_configs: true
 provision_config_files:
   - /etc/resolv.conf

--- a/aminator/plugins/provisioner/base.py
+++ b/aminator/plugins/provisioner/base.py
@@ -85,9 +85,9 @@ class BaseProvisionerPlugin(BasePlugin):
         log.debug('Pre chroot command block')
         self._pre_chroot_block()
 
-        log.debug('Entering chroot at {0}'.format(self._distro._mountpoint))
+        log.debug('Entering chroot at {0}'.format(self._distro.root_mountspec.mountpoint))
 
-        with Chroot(self._distro._mountpoint):
+        with Chroot(self._distro.root_mountspec.mountpoint):
             log.debug('Inside chroot')
 
             result = self._provision_package()
@@ -167,7 +167,9 @@ class BaseProvisionerPlugin(BasePlugin):
         """
         context = self._config.context
         context.package.file = os.path.basename(context.package.arg)
-        context.package.full_path = os.path.join(self._distro._mountpoint, context.package.dir.lstrip('/'), context.package.file)
+        root_path = self._distro.root_mountspec.mountpoint
+        stage_path = os.path.join(root_path, context.package.dir.lstrip('/'))
+        context.package.full_path = os.path.join(stage_path, context.package.file)
         try:
             if any(protocol in context.package.arg for protocol in ['http://', 'https://']):
                 self._download_pkg(context)


### PR DESCRIPTION
This consolidates mounting/unmounting in the chroot components in the distro plugins rather than have some handled by the volume plugin and some handled by the distro plugin.
In addition, it adds support for configurable use of `umount --recursive`, tries to unmount things if something goes wrong during chroot setup, and provides a cleaner view of open files in `busy_mount` when looking for open files against a bind mount that may have open handles outside the chroot.