### PR TITLE
checking for presence of mountspec.mountpoint to prevent error

### DIFF
--- a/aminator/plugins/distro/linux.py
+++ b/aminator/plugins/distro/linux.py
@@ -107,7 +107,8 @@ class BaseLinuxDistroPlugin(BaseDistroPlugin):
                 if open_files.success:
                     err = '{0}. Device has open files:\n{1}'.format(err, open_files.result.std_out)
                 raise VolumeException(err)
-        log.debug('Unmounted {0.mountpoint}'.format(mountspec))
+        if hasattr(mountspec, 'mountpoint'):
+            log.debug('Unmounted {0.mountpoint}'.format(mountspec))
 
     @fails("aminator.distro.linux.configure_chroot.error")
     @timer("aminator.distro.linux.configure_chroot.duration")

--- a/aminator/util/linux.py
+++ b/aminator/util/linux.py
@@ -139,6 +139,9 @@ def monitor_command(cmd, timeout=None):
 
 
 def mounted(mountspec):
+    if not hasattr(mountspec, 'mountpoint'):
+        return False
+        
     pat = mountspec.mountpoint.strip() + ' '
     with open('/proc/mounts') as mounts:
         return any(pat in mount for mount in mounts)


### PR DESCRIPTION
I was executing 
aminate -B ami-0a313d6098716f372 --vm-type hvm --partition 1 -e ec2_apt_linux ./hello-world_1.0.0_all.deb

that execution failed due to missing attribute mountspec.mountpoint in certain phase of execution.

I am not a python developer. I did what I can to get aminator to work for me.

I tried this on a EC2 instance and updated the distro/linux.py and util/linux.py to get the aminator to complete the creation of my AMI.

Please, educate me if I am missing a aminator CLI parameter or if my parameters are wrong.